### PR TITLE
compress image and save chapter as CBZ(zip) 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -143,7 +143,7 @@ class DownloadCache(
             mangaDirs.values.forEach { mangaDir ->
                 val chapterDirs = mangaDir.dir.listFiles()
                     .orEmpty()
-                    .mapNotNull { it.name }
+                    .mapNotNull { it.name?.replace(".cbz","") }
                     .toHashSet()
 
                 mangaDir.files = chapterDirs

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -88,7 +88,7 @@ class DownloadProvider(private val context: Context) {
      */
     fun findChapterDir(chapter: Chapter, manga: Manga, source: Source): UniFile? {
         val mangaDir = findMangaDir(manga, source)
-        return mangaDir?.findFile(getChapterDirName(chapter))
+        return mangaDir?.findFile(getChapterDirName(chapter)) ?:  mangaDir?.findFile(getChapterDirName(chapter)+".cbz")
     }
 
     /**
@@ -100,7 +100,7 @@ class DownloadProvider(private val context: Context) {
      */
     fun findChapterDirs(chapters: List<Chapter>, manga: Manga, source: Source): List<UniFile> {
         val mangaDir = findMangaDir(manga, source) ?: return emptyList()
-        return chapters.mapNotNull { mangaDir.findFile(getChapterDirName(it)) }
+        return chapters.mapNotNull { mangaDir.findFile(getChapterDirName(it))?:mangaDir.findFile(getChapterDirName(it)+".cbz")  }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -276,4 +276,8 @@ object PreferenceKeys {
     const val filterWebp = "pref_filter_webp"
 
     const val compressionHost = "pref_compression_host"
+
+    const val zipLevel = "pref_zip_level"
+
+    const val saveASZip = "pref_save_as_zip"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -268,4 +268,12 @@ object PreferenceKeys {
     const val sources_tab_source_categories = "sources_tab_source_categories"
 
     const val sourcesSort = "sources_sort"
+
+    const val enableCompression = "pref_enable_compression"
+
+    const val filterJpeg = "pref_filter_jpeg"
+
+    const val filterWebp = "pref_filter_webp"
+
+    const val compressionHost = "pref_compression_host"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -376,4 +376,8 @@ class PreferencesHelper(val context: Context) {
     fun filterWebp() = flowPrefs.getBoolean(Keys.filterWebp, false)
 
     fun compressionHost() = flowPrefs.getString(Keys.compressionHost, "")
+
+    fun saveASZip() = flowPrefs.getBoolean(Keys.saveASZip, false)
+
+    fun zipLevel() = flowPrefs.getInt(Keys.zipLevel, 0)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -368,4 +368,12 @@ class PreferencesHelper(val context: Context) {
     fun sourcesTabSourcesInCategories() = flowPrefs.getStringSet(Keys.sources_tab_source_categories, mutableSetOf())
 
     fun sourceSorting() = flowPrefs.getInt(Keys.sourcesSort, 0)
+
+    fun enableCompression() = flowPrefs.getBoolean(Keys.enableCompression, false)
+
+    fun filterJpeg() = flowPrefs.getBoolean(Keys.filterJpeg, false)
+
+    fun filterWebp() = flowPrefs.getBoolean(Keys.filterWebp, false)
+
+    fun compressionHost() = flowPrefs.getString(Keys.compressionHost, "")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -4,12 +4,17 @@ import android.app.Application
 import android.net.Uri
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
+import eu.kanade.tachiyomi.util.system.ImageUtil
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
 
 /**
  * Loader used to load a chapter from the downloaded chapters.
@@ -26,20 +31,40 @@ class DownloadPageLoader(
      */
     private val context by injectLazy<Application>()
 
+    private val downloadProvider by lazy { DownloadProvider(context) }
+
     /**
      * Returns an observable containing the pages found on this downloaded chapter.
      */
     override fun getPages(): Observable<List<ReaderPage>> {
-        return downloadManager.buildPageList(source, manga, chapter.chapter)
-            .map { pages ->
-                pages.map { page ->
-                    ReaderPage(page.index, page.url, page.imageUrl) {
-                        context.contentResolver.openInputStream(page.uri ?: Uri.EMPTY)!!
-                    }.apply {
-                        status = Page.READY
+        val chapterPath = downloadProvider.findChapterDir(chapter.chapter, manga, source)
+
+        if (chapterPath?.isFile!!) {
+            val zip = ZipFile(chapterPath.filePath)
+            return zip.entries().toList()
+                    .filter { !it.isDirectory && ImageUtil.isImage(it.name) { zip.getInputStream(it) } }
+                    .sortedWith(Comparator<ZipEntry> { f1, f2 -> f1.name.compareToCaseInsensitiveNaturalOrder(f2.name) })
+                    .mapIndexed { i, entry ->
+                        val streamFn = { zip.getInputStream(entry) }
+                        ReaderPage(i).apply {
+                            stream = streamFn
+                            status = Page.READY
+                        }
                     }
-                }
-            }
+                    .let { Observable.just(it) }
+        } else {
+
+            return downloadManager.buildPageList(source, manga, chapter.chapter)
+                    .map { pages ->
+                        pages.map { page ->
+                            ReaderPage(page.index, page.url, page.imageUrl) {
+                                context.contentResolver.openInputStream(page.uri ?: Uri.EMPTY)!!
+                            }.apply {
+                                status = Page.READY
+                            }
+                        }
+                    }
+        }
     }
 
     override fun getPage(page: ReaderPage): Observable<Int> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsExperimentController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsExperimentController.kt
@@ -11,28 +11,34 @@ class SettingsExperimentController : SettingsController() {
         title = "Experimental Features"
 
         switchPreference {
-            key = PreferenceKeys.enableCompression
-            title = "Enable Compression"
+            key = PreferenceKeys.saveASZip
+            title = "Save Chapter As CBZ(Zip)"
             defaultValue = false
-        }
 
-        switchPreference {
-            key = PreferenceKeys.filterWebp
-            title = "Filter WEBp"
-            defaultValue = false
-        }
-        switchPreference {
-            key = PreferenceKeys.filterJpeg
-            title = "Filter JPEG"
-            defaultValue = false
-        }
+            switchPreference {
+                key = PreferenceKeys.enableCompression
+                title = "Enable Compression"
+                defaultValue = false
+            }
 
-        editTextPreference {
-            key = PreferenceKeys.compressionHost
-            title = "Compression Host"
-            summary = preferences.compressionHost().get()
-            defaultValue = ""
-        }
+            switchPreference {
+                key = PreferenceKeys.filterWebp
+                title = "Filter WEBp"
+                defaultValue = false
+            }
+            switchPreference {
+                key = PreferenceKeys.filterJpeg
+                title = "Filter JPEG"
+                defaultValue = false
+            }
 
+            editTextPreference {
+                key = PreferenceKeys.compressionHost
+                title = "Compression Host"
+                summary = preferences.compressionHost().get()
+                defaultValue = ""
+            }
+
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsExperimentController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsExperimentController.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.ui.setting
+
+import androidx.preference.PreferenceScreen
+import eu.kanade.tachiyomi.data.preference.PreferenceKeys
+import eu.kanade.tachiyomi.util.preference.defaultValue
+import eu.kanade.tachiyomi.util.preference.editTextPreference
+import eu.kanade.tachiyomi.util.preference.switchPreference
+
+class SettingsExperimentController : SettingsController() {
+    override fun setupPreferenceScreen(screen: PreferenceScreen) = with(screen) {
+        title = "Experimental Features"
+
+        switchPreference {
+            key = PreferenceKeys.enableCompression
+            title = "Enable Compression"
+            defaultValue = false
+        }
+
+        switchPreference {
+            key = PreferenceKeys.filterWebp
+            title = "Filter WEBp"
+            defaultValue = false
+        }
+        switchPreference {
+            key = PreferenceKeys.filterJpeg
+            title = "Filter JPEG"
+            defaultValue = false
+        }
+
+        editTextPreference {
+            key = PreferenceKeys.compressionHost
+            title = "Compression Host"
+            summary = preferences.compressionHost().get()
+            defaultValue = ""
+        }
+
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
@@ -93,6 +93,13 @@ class SettingsMainController : SettingsController() {
             titleRes = R.string.pref_category_advanced
             onClick { navigateTo(SettingsAdvancedController()) }
         }
+
+        preference {
+            iconRes = R.drawable.ic_code_24dp
+            iconTint = tintColor
+            title = "Experimental Features"
+            onClick { navigateTo(SettingsExperimentController()) }
+        }
     }
 
     private fun navigateTo(controller: SettingsController) {


### PR DESCRIPTION
- compress images before downloading or loading in reader using bandwithhero server. server url is not included so users have to create their own server for free in heroku if they want to use this feature.

add option save chapter as cbz. it uses zipfile api so there is no need to unzip images. it can directly read image from zip file so its not slow. 