### PR TITLE
Fix title on light theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -67,7 +67,7 @@
 
         <!-- Material Dialogs -->
         <item name="md_background_color">?attr/colorSurface</item>
-        <item name="md_color_title">?attr/colorOnSurface</item>
+        <item name="md_color_title">@color/md_white_1000</item>
         <item name="md_color_content">?attr/colorOnSurface</item>
         <item name="md_color_button_text">?attr/colorAccent</item>
         <item name="md_button_casing">literal</item>


### PR DESCRIPTION
md_color_title doesn't seem to be used anywhere except for the manga titles according to my search on ApkEditor (you know, because forks can't be searched😔), and original repo doesn't even seem to be using it for anything - so there shouldn't be unintended consequences. 