### PR TITLE
Change Similar manga settings layout

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMangaDexController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMangaDexController.kt
@@ -156,7 +156,7 @@ class SettingsMangaDexController :
 
             preference {
                 key = "similar_credits"
-                title = "Credits"
+                titleRes = R.string.similar_credit
                 val url = "https://github.com/goldbattle/MangadexRecomendations"
                 summary = context.getString(R.string.similar_credit_message, url)
                 onClick {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMangaDexController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMangaDexController.kt
@@ -100,7 +100,6 @@ class SettingsMangaDexController :
 
             preference {
                 key = "pref_similar_screen"
-                titleRes = R.string.similar_screen
                 summaryRes = R.string.similar_screen_summary_message
                 isIconSpaceReserved = true
             }

--- a/app/src/main/res/values/strings_sy.xml
+++ b/app/src/main/res/values/strings_sy.xml
@@ -624,6 +624,7 @@
         demographics, content type, themes, and then using term frequency–inverse document frequency (tf–idf) to get the
         similarity of two manga\'s descriptions. When enabled this file will download immediately!! The file is about 9 MB in size.
     </string>
+    <string name="similar_credit">Credits</string>
     <string name="similar_credit_message">
         For more information and to view the source code:\n%s
     </string>
@@ -659,6 +660,5 @@
         <item quantity="other">%1$d second ago</item>
     </plurals>
     <string name="humanize_fallback">moments ago</string>
-
 
 </resources>


### PR DESCRIPTION
This PR makes changes in displaying Similar Manga Settings

There are two changes made:
1. Remove redundant R.string.similar_screen text from the settings
2. Replace the "Credits" string with a new appropriate element in strings_sy.xml, aiding complete translation

| before | after |
| --- | --- |
| ![Screenshot_2021-02-26-01-04-42-093_eu kanade tachiyomi sy](https://user-images.githubusercontent.com/72807749/109207159-cf4f9680-77ce-11eb-844b-b86a8e5e0ef7.jpg) | ![Screenshot_2021-02-26-00-59-50-027_eu kanade tachiyomi sy debug](https://user-images.githubusercontent.com/72807749/109206702-34ef5300-77ce-11eb-9b45-488947ab3f0e.jpg) |
