### PR TITLE
fixes to Migration menu layouts

### DIFF
--- a/app/src/main/res/layout/migration_manga_card.xml
+++ b/app/src/main/res/layout/migration_manga_card.xml
@@ -74,6 +74,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:ellipsize="end"
+            android:fontFamily="@font/ptsans_narrow_bold"
             android:lineSpacingExtra="-4dp"
             android:maxLines="2"
             android:padding="8dp"
@@ -81,6 +82,7 @@
             android:shadowDx="0"
             android:shadowDy="0"
             android:shadowRadius="4"
+            android:textColor="@color/md_white_1000"
             tools:text="Sample name" />
 
         <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/app/src/main/res/layout/migration_process_item.xml
+++ b/app/src/main/res/layout/migration_process_item.xml
@@ -57,8 +57,8 @@
         app:layout_constraintStart_toEndOf="@+id/migration_manga_card_to"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_more_vert_24dp"
-        android:visibility="invisible"/>
-
+        android:visibility="invisible"
+        app:tint="?attr/colorOnPrimary" />
 
     <ImageView
         android:id="@+id/skip_manga"


### PR DESCRIPTION
Do test them out locally before merging the PR

fix Migration process item option button color
fixes #287 

![Screenshot_20210430-133840](https://user-images.githubusercontent.com/72807749/116667434-d2772680-a9b9-11eb-90b0-368bbdf4575d.png)

fix migration manga card layout for white theme

![Screenshot_20210430-133802](https://user-images.githubusercontent.com/72807749/116667505-e4f16000-a9b9-11eb-9492-7f454d4327dd.png)
