### PR TITLE
Fix + appearing on `ConfigurableSources` in Browse > Extensions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
@@ -98,7 +98,9 @@ class ExtensionHolder(view: View, val adapter: ExtensionAdapter) :
             }
         )
         // SY -->
-        if (extension is Extension.Installed && extension.sources.any { it is ConfigurableSource }) {
+        if (installStep == InstallStep.Idle
+            && extension is Extension.Installed
+            && extension.sources.any { it is ConfigurableSource }) {
             @SuppressLint("SetTextI18n")
             text = "$text+"
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionHolder.kt
@@ -98,9 +98,10 @@ class ExtensionHolder(view: View, val adapter: ExtensionAdapter) :
             }
         )
         // SY -->
-        if (installStep == InstallStep.Idle
-            && extension is Extension.Installed
-            && extension.sources.any { it is ConfigurableSource }) {
+        if (installStep == InstallStep.Idle &&
+            extension is Extension.Installed &&
+            extension.sources.any { it is ConfigurableSource }
+        ) {
             @SuppressLint("SetTextI18n")
             text = "$text+"
         }

--- a/app/src/main/res/layout/extension_card_item.xml
+++ b/app/src/main/res/layout/extension_card_item.xml
@@ -80,6 +80,7 @@
         style="?attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textAlignment="textEnd"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/cancel_button"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
"+" needs to be added only if the following conditions are met:
 - Extension is Installed and is a ConfigurableSource (regardless of it
   having an Update or not)
 - Extension is in InstallStep.Idle state
 
Also tried to align the text (`Settings/Settings+` etc) to the right end rather
than letting it be centred. Can remove if not required.

### Images

| Before | Now | Now (non-Idle state) |
| ------- | ------- | ---- |
| ![Screenshot_20211002-202538_TachiyomiSY_1](https://user-images.githubusercontent.com/72807749/135722035-43ee3e4f-a7df-478b-b62e-a1b2d1e15039.png) | ![Screenshot_20211002-202453_TachiyomiSY_1](https://user-images.githubusercontent.com/72807749/135722036-f3bb5ff9-ff89-444f-800f-34d178dc4692.png) | ![Screenshot_20211002-202619_TachiyomiSY_1](https://user-images.githubusercontent.com/72807749/135722031-5d0b52b1-b35b-405d-8ac0-8793e7026bd8.png) |
