### PR TITLE
Center padding option for Surface Duos/other foldables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 | Preview Builds | Release Builds | Tachiyomi Support Server |
 |-------|----------|----------|
 
-** This fork adds an experimental center padding option to dual page views to accomodate Surface Duo devices.
-
 # ![app icon](./.github/readme-images/app-icon.png)TachiyomiSY
 Tachiyomi is a free and open source manga reader for Android 6.0 and above. This version of Tachiyomi, TachiyomiSY was based off TachiyomiAZ. This version is meant to push forward in the ways of usability and features. TachiyomiSY tries to push forward where it can, but staying in a place where it can easily grab updates and features from the main app, it tries to make new features, or take features from other forks like J2K and Neko.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 | Preview Builds | Release Builds | Tachiyomi Support Server |
 |-------|----------|----------|
-| [![Preview](https://github.com/jobobby04/TachiyomiSYPreview/workflows/Remote%20Dispatch%20Build%20App/badge.svg)](https://github.com/jobobby04/TachiyomiSYPreview/releases) | [![stable release](https://img.shields.io/github/release/jobobby04/tachiyomisy.svg?maxAge=3600&label=download)](https://github.com/jobobby04/tachiyomisy/releases/latest) | [![Discord](https://img.shields.io/discord/349436576037732353.svg?label=discord&labelColor=7289da&color=2c2f33&style=flat)](https://discord.gg/tachiyomi) |
 
+** This fork adds an experimental center padding option to dual page views to accomodate Surface Duo devices.
 
 # ![app icon](./.github/readme-images/app-icon.png)TachiyomiSY
 Tachiyomi is a free and open source manga reader for Android 6.0 and above. This version of Tachiyomi, TachiyomiSY was based off TachiyomiAZ. This version is meant to push forward in the ways of usability and features. TachiyomiSY tries to push forward where it can, but staying in a place where it can easily grab updates and features from the main app, it tries to make new features, or take features from other forks like J2K and Neko.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 | Preview Builds | Release Builds | Tachiyomi Support Server |
 |-------|----------|----------|
+| [![Preview](https://github.com/jobobby04/TachiyomiSYPreview/workflows/Remote%20Dispatch%20Build%20App/badge.svg)](https://github.com/jobobby04/TachiyomiSYPreview/releases) | [![stable release](https://img.shields.io/github/release/jobobby04/tachiyomisy.svg?maxAge=3600&label=download)](https://github.com/jobobby04/tachiyomisy/releases/latest) | [![Discord](https://img.shields.io/discord/349436576037732353.svg?label=discord&labelColor=7289da&color=2c2f33&style=flat)](https://discord.gg/tachiyomi) |
+
 
 # ![app icon](./.github/readme-images/app-icon.png)TachiyomiSY
 Tachiyomi is a free and open source manga reader for Android 6.0 and above. This version of Tachiyomi, TachiyomiSY was based off TachiyomiAZ. This version is meant to push forward in the ways of usability and features. TachiyomiSY tries to push forward where it can, but staying in a place where it can easily grab updates and features from the main app, it tries to make new features, or take features from other forks like J2K and Neko.
@@ -83,8 +85,8 @@ Please make sure to read the full guidelines. Your issue may be closed without w
 <details><summary>Bugs</summary>
 
 * Include version (More → About → Version)
- * If not latest, try updating, it may have already been solved
- * Preview version is equal to the number of commits as seen in the main page
+* If not latest, try updating, it may have already been solved
+* Preview version is equal to the number of commits as seen in the main page
 * Include steps to reproduce (if not obvious from description)
 * Include screenshot (if needed)
 * If it could be device-dependent, try reproducing on another device (if possible)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -514,7 +514,7 @@ class PreferencesHelper(val context: Context) {
 
     fun pageLayout() = flowPrefs.getInt("page_layout", PagerConfig.PageLayout.AUTOMATIC)
 
-    fun invertDoublePages() = flowPrefs.getBoolean("invert_double_pages", false)
+    fun centerMarginType() = flowPrefs.getInt("center_margin_type", PagerConfig.CenterMarginType.NONE)
 
-    fun addDoublePageCenterMargin() = flowPrefs.getBoolean("add_double_page_center_margin", false)
+    fun invertDoublePages() = flowPrefs.getBoolean("invert_double_pages", false)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -515,4 +515,6 @@ class PreferencesHelper(val context: Context) {
     fun pageLayout() = flowPrefs.getInt("page_layout", PagerConfig.PageLayout.AUTOMATIC)
 
     fun invertDoublePages() = flowPrefs.getBoolean("invert_double_pages", false)
+
+    fun addDoublePageCenterMargin() = flowPrefs.getBoolean("add_double_page_center_margin", false)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -827,7 +827,7 @@ class ReaderPresenter(
 
         return imageSaver.save(
             image = Image.Page(
-                inputStream = { ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, bg) },
+                inputStream = { ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, 0, bg) },
                 name = filename,
                 location = location,
             ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
@@ -97,7 +97,7 @@ class ReaderReadingModeSettings @JvmOverloads constructor(context: Context, attr
         binding.pagerPrefsGroup.pageTransitionsPager.bindToPreference(preferences.pageTransitionsPager())
         binding.pagerPrefsGroup.pageLayout.bindToPreference(preferences.pageLayout())
         binding.pagerPrefsGroup.invertDoublePages.bindToPreference(preferences.invertDoublePages())
-        binding.pagerPrefsGroup.addDoublePageCenterMargin.bindToPreference(preferences.addDoublePageCenterMargin())
+        binding.pagerPrefsGroup.centerMarginType.bindToPreference(preferences.centerMarginType())
         // SY <--
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderReadingModeSettings.kt
@@ -97,6 +97,7 @@ class ReaderReadingModeSettings @JvmOverloads constructor(context: Context, attr
         binding.pagerPrefsGroup.pageTransitionsPager.bindToPreference(preferences.pageTransitionsPager())
         binding.pagerPrefsGroup.pageLayout.bindToPreference(preferences.pageLayout())
         binding.pagerPrefsGroup.invertDoublePages.bindToPreference(preferences.invertDoublePages())
+        binding.pagerPrefsGroup.addDoublePageCenterMargin.bindToPreference(preferences.addDoublePageCenterMargin())
         // SY <--
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -67,6 +67,8 @@ class PagerConfig(
 
     var invertDoublePages = false
 
+    var addDoublePageCenterMargin = false
+
     var autoDoublePages = preferences.pageLayout().get() == PageLayout.AUTOMATIC
 
     @ColorInt
@@ -149,7 +151,8 @@ class PagerConfig(
                     reloadChapterListener?.invoke(doublePages)
                 },
             )
-
+        preferences.addDoublePageCenterMargin()
+            .register({ addDoublePageCenterMargin = it && dualPageSplit == false && imageCropBorders == false }, { imagePropertyChangedListener?.invoke() })
         preferences.invertDoublePages()
             .register({ invertDoublePages = it && dualPageSplit == false }, { imagePropertyChangedListener?.invoke() })
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -67,12 +67,13 @@ class PagerConfig(
 
     var invertDoublePages = false
 
-    var addDoublePageCenterMargin = false
-
     var autoDoublePages = preferences.pageLayout().get() == PageLayout.AUTOMATIC
 
     @ColorInt
     var pageCanvasColor = Color.WHITE
+
+    var centerMarginType = CenterMarginType.NONE
+
     // SY <--
 
     init {
@@ -151,8 +152,10 @@ class PagerConfig(
                     reloadChapterListener?.invoke(doublePages)
                 },
             )
-        preferences.addDoublePageCenterMargin()
-            .register({ addDoublePageCenterMargin = it && dualPageSplit == false && imageCropBorders == false }, { imagePropertyChangedListener?.invoke() })
+
+        preferences.centerMarginType()
+            .register({ centerMarginType = it }, { imagePropertyChangedListener?.invoke() })
+
         preferences.invertDoublePages()
             .register({ invertDoublePages = it && dualPageSplit == false }, { imagePropertyChangedListener?.invoke() })
         // SY <--
@@ -198,6 +201,13 @@ class PagerConfig(
             else -> defaultNavigation()
         }
         navigationModeChangedListener?.invoke()
+    }
+
+    object CenterMarginType {
+        const val NONE = 0
+        const val DOUBLE_PAGE_CENTER_MARGIN = 1
+        const val WIDE_PAGE_CENTER_MARGIN = 2
+        const val DOUBLE_AND_WIDE_CENTER_MARGIN = 3
     }
 
     object PageLayout {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -28,6 +28,7 @@ import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 /**
@@ -353,8 +354,6 @@ class PagerPageHolder(
     }
 
     private fun mergePages(imageStream: InputStream, imageStream2: InputStream?): InputStream {
-        // SY -->
-
         // Handle adding a center margin to wide images if requested
         if (imageStream2 == null) {
             if (imageStream is BufferedInputStream && ImageUtil.isWideImage(imageStream) &&
@@ -432,7 +431,7 @@ class PagerPageHolder(
 
         val centerMargin = if (viewer.config.centerMarginType and PagerConfig.CenterMarginType.DOUBLE_PAGE_CENTER_MARGIN > 0 &&
             !viewer.config.imageCropBorders
-        ) 96 / (Math.max(1, getHeight()) / Math.max(height, height2)) else 0
+        ) 96 / (max(1, getHeight()) / max(height, height2)) else 0
 
         return ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, centerMargin, viewer.config.pageCanvasColor) {
             viewer.scope.launchUI {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -416,7 +416,10 @@ class PagerPageHolder(
 
         imageStream.close()
         imageStream2.close()
-        return ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, viewer.config.pageCanvasColor) {
+
+        val centerMargin = if (viewer.config.addDoublePageCenterMargin && !viewer.config.imageCropBorders) 96 / (Math.max(1, getHeight()) / Math.max(height, height2)) else 0
+
+        return ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, centerMargin, viewer.config.pageCanvasColor) {
             viewer.scope.launchUI {
                 if (it == 100) {
                     progressIndicator.hide()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -508,6 +508,12 @@ class SettingsReaderController : SettingsController() {
                 titleRes = R.string.invert_double_pages
                 visibleIf(preferences.pageLayout()) { it != PagerConfig.PageLayout.SINGLE_PAGE }
             }
+
+            switchPreference {
+                bindTo(preferences.addDoublePageCenterMargin())
+                titleRes = R.string.add_double_page_center_margin
+                visibleIf(preferences.pageLayout()) { it != PagerConfig.PageLayout.SINGLE_PAGE }
+            }
         }
         // SY <--
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -509,10 +509,16 @@ class SettingsReaderController : SettingsController() {
                 visibleIf(preferences.pageLayout()) { it != PagerConfig.PageLayout.SINGLE_PAGE }
             }
 
-            switchPreference {
-                bindTo(preferences.addDoublePageCenterMargin())
-                titleRes = R.string.add_double_page_center_margin
-                visibleIf(preferences.pageLayout()) { it != PagerConfig.PageLayout.SINGLE_PAGE }
+            intListPreference {
+                bindTo(preferences.centerMarginType())
+                titleRes = R.string.center_margin
+                entriesRes = arrayOf(
+                    R.string.center_margin_none,
+                    R.string.center_margin_double_page,
+                    R.string.center_margin_wide_page,
+                    R.string.center_margin_double_and_wide_page,
+                )
+                entryValues = arrayOf("0", "1", "2", "3")
             }
         }
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -1,5 +1,4 @@
 package eu.kanade.tachiyomi.util.system
-
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Bitmap
@@ -189,12 +188,11 @@ object ImageUtil {
      */
 
     fun AddHorizontalCenterMargin(imageStream: InputStream, viewHeight: Int, backgroundContext: Context): InputStream {
-        val imageBytes = imageStream.readBytes()
-        val imageBitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+        val imageBitmap = ImageDecoder.newInstance(imageStream)?.decode()!!
         val height = imageBitmap.height
         val width = imageBitmap.width
 
-        val centerPadding = 96 / (Math.max(1, viewHeight) / height)
+        val centerPadding = 96 / (max(1, viewHeight) / height)
 
         val leftSourcePart = Rect(0, 0, width / 2, height)
         val rightSourcePart = Rect(width / 2, 0, width, height)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -487,31 +487,37 @@ object ImageUtil {
         imageBitmap: Bitmap,
         imageBitmap2: Bitmap,
         isLTR: Boolean,
+        centerMargin: Int,
         @ColorInt background: Int = Color.WHITE,
+
         progressCallback: ((Int) -> Unit)? = null,
     ): ByteArrayInputStream {
         val height = imageBitmap.height
         val width = imageBitmap.width
         val height2 = imageBitmap2.height
         val width2 = imageBitmap2.width
+
         val maxHeight = max(height, height2)
-        val result = Bitmap.createBitmap(width + width2, max(height, height2), Bitmap.Config.ARGB_8888)
+
+        val result = Bitmap.createBitmap(width + width2 + centerMargin, max(height, height2), Bitmap.Config.ARGB_8888)
         val canvas = Canvas(result)
         canvas.drawColor(background)
         val upperPart = Rect(
-            if (isLTR) 0 else width2,
+            if (isLTR) 0 else width2 + centerMargin,
             (maxHeight - imageBitmap.height) / 2,
-            (if (isLTR) 0 else width2) + imageBitmap.width,
+            (if (isLTR) 0 else width2 + centerMargin) + imageBitmap.width,
             imageBitmap.height + (maxHeight - imageBitmap.height) / 2,
         )
+
         canvas.drawBitmap(imageBitmap, imageBitmap.rect, upperPart, null)
         progressCallback?.invoke(98)
         val bottomPart = Rect(
-            if (!isLTR) 0 else width,
+            if (!isLTR) 0 else width + centerMargin,
             (maxHeight - imageBitmap2.height) / 2,
-            (if (!isLTR) 0 else width) + imageBitmap2.width,
+            (if (!isLTR) 0 else width + centerMargin) + imageBitmap2.width,
             imageBitmap2.height + (maxHeight - imageBitmap2.height) / 2,
         )
+
         canvas.drawBitmap(imageBitmap2, imageBitmap2.rect, bottomPart, null)
         progressCallback?.invoke(99)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -181,38 +181,41 @@ object ImageUtil {
     enum class Side {
         RIGHT, LEFT
     }
-
+    // SY -->
     /**
      * Split the image into left and right parts, then merge them into a
      * new image with added center padding scaled relative to the height of the display view
      * to compensate for scaling.
      */
 
-    fun AddHorizontalCenterMargin(imageStream: InputStream, viewHeight: Int): InputStream {
+    fun AddHorizontalCenterMargin(imageStream: InputStream, viewHeight: Int, backgroundContext: Context): InputStream {
         val imageBytes = imageStream.readBytes()
         val imageBitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
         val height = imageBitmap.height
         val width = imageBitmap.width
 
-        val leftSourcePart = Rect(0, 0, width / 2, height)
-        val rightSourcePart = Rect(width / 2, 0, width, height)
-
         val centerPadding = 96 / (Math.max(1, viewHeight) / height)
 
+        val leftSourcePart = Rect(0, 0, width / 2, height)
+        val rightSourcePart = Rect(width / 2, 0, width, height)
         val leftTargetPart = Rect(0, 0, width / 2, height)
         val rightTargetPart = Rect(width / 2 + centerPadding, 0, width + centerPadding, height)
 
+        val bgColor = chooseBackground(backgroundContext, imageStream)
+        bgColor.setBounds(width / 2, 0, width / 2 + centerPadding, height)
         val result = createBitmap(width + centerPadding, height)
 
         result.applyCanvas {
             drawBitmap(imageBitmap, leftSourcePart, leftTargetPart, null)
             drawBitmap(imageBitmap, rightSourcePart, rightTargetPart, null)
+            bgColor.draw(this)
         }
 
         val output = ByteArrayOutputStream()
         result.compress(Bitmap.CompressFormat.JPEG, 100, output)
         return ByteArrayInputStream(output.toByteArray())
     }
+    // SY <--
 
     /**
      * Check whether the image is considered a tall image.

--- a/app/src/main/res/layout/reader_pager_settings.xml
+++ b/app/src/main/res/layout/reader_pager_settings.xml
@@ -116,6 +116,15 @@
         android:textColor="?android:attr/textColorSecondary"
         android:text="@string/invert_double_pages" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/add_double_page_center_margin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:text="@string/add_double_page_center_margin"
+        android:textColor="?android:attr/textColorSecondary" />
+
     <androidx.constraintlayout.widget.Group
         android:id="@+id/tapping_prefs_group"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/reader_pager_settings.xml
+++ b/app/src/main/res/layout/reader_pager_settings.xml
@@ -116,14 +116,12 @@
         android:textColor="?android:attr/textColorSecondary"
         android:text="@string/invert_double_pages" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/add_double_page_center_margin"
+    <eu.kanade.tachiyomi.widget.MaterialSpinnerView
+        android:id="@+id/center_margin_type"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:text="@string/add_double_page_center_margin"
-        android:textColor="?android:attr/textColorSecondary" />
+        android:entries="@array/center_margin_types"
+        app:title="@string/pref_center_margin" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/tapping_prefs_group"

--- a/app/src/main/res/values/arrays_sy.xml
+++ b/app/src/main/res/values/arrays_sy.xml
@@ -21,4 +21,11 @@
         <item>@string/double_pages</item>
         <item>@string/automatic_orientation</item>
     </string-array>
+
+    <string-array name="center_margin_types">
+        <item>@string/center_margin_none</item>
+        <item>@string/center_margin_double_page</item>
+        <item>@string/center_margin_wide_page</item>
+        <item>@string/center_margin_double_and_wide_page</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,8 @@
     <string name="pref_show_navigation_mode">Show tap zones overlay</string>
     <string name="pref_show_navigation_mode_summary">Briefly show when reader is opened</string>
     <string name="pref_dual_page_split">Dual page split</string>
+    <string name="pref_center_margin">Center margin type</string>
+    <string name="pref_center_margin_summary">Insert spacer to accommodate deadspace on foldable devices.</string>
     <string name="pref_dual_page_invert">Invert dual page split placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the dual page split doesn\'t match reading direction</string>
     <string name="pref_cutout_short">Show content in cutout area</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,8 +290,6 @@
     <string name="pref_show_navigation_mode">Show tap zones overlay</string>
     <string name="pref_show_navigation_mode_summary">Briefly show when reader is opened</string>
     <string name="pref_dual_page_split">Dual page split</string>
-    <string name="pref_center_margin">Center margin type</string>
-    <string name="pref_center_margin_summary">Insert spacer to accommodate deadspace on foldable devices.</string>
     <string name="pref_dual_page_invert">Invert dual page split placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the dual page split doesn\'t match reading direction</string>
     <string name="pref_cutout_short">Show content in cutout area</string>

--- a/app/src/main/res/values/strings_sy.xml
+++ b/app/src/main/res/values/strings_sy.xml
@@ -313,7 +313,13 @@
     <string name="automatic_orientation">Automatic (based on orientation)</string>
     <string name="automatic_can_still_switch">While using automatic page layout, you can still switch between layouts while reading without overriding this setting</string>
     <string name="invert_double_pages">Invert double pages</string>
-    <string name="add_double_page_center_margin">Add double page center margin</string>
+
+    <!-- Center margin -->
+    <string name="center_margin">Center Margin</string>
+    <string name="center_margin_none">None</string>
+    <string name="center_margin_double_page">Add to double Page</string>
+    <string name="center_margin_wide_page">Add to wide Page</string>
+    <string name="center_margin_double_and_wide_page">Add to both</string>
 
     <!-- Manga Page -->
     <!-- Manga Info -->

--- a/app/src/main/res/values/strings_sy.xml
+++ b/app/src/main/res/values/strings_sy.xml
@@ -320,6 +320,8 @@
     <string name="center_margin_double_page">Add to double Page</string>
     <string name="center_margin_wide_page">Add to wide Page</string>
     <string name="center_margin_double_and_wide_page">Add to both</string>
+    <string name="pref_center_margin">Center margin type</string>
+    <string name="pref_center_margin_summary">Insert spacer to accommodate deadspace on foldable devices.</string>
 
     <!-- Manga Page -->
     <!-- Manga Info -->

--- a/app/src/main/res/values/strings_sy.xml
+++ b/app/src/main/res/values/strings_sy.xml
@@ -313,6 +313,7 @@
     <string name="automatic_orientation">Automatic (based on orientation)</string>
     <string name="automatic_can_still_switch">While using automatic page layout, you can still switch between layouts while reading without overriding this setting</string>
     <string name="invert_double_pages">Invert double pages</string>
+    <string name="add_double_page_center_margin">Add double page center margin</string>
 
     <!-- Manga Page -->
     <!-- Manga Info -->


### PR DESCRIPTION
Basic implementation of center margins for #628.

This adds a dropdown selector to the bottom of reader preferences when in dual-page mode which allows the user to specify if they want margins inserted between double-page spreads, in the center of large images, both, or neither. The margin is currently fixed at 96px wide as that seems to be the standard size for 'display features' (aka don't-render-here deadspace) according to the android foldables guidelines.

