### PR TITLE
Able to move 'Merge' button to the overflow menu

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -300,8 +300,10 @@ private fun MangaScreenSmallImpl(
                 onEditInfoClicked = onEditInfoClicked,
                 showRecommends = state.showRecommendationsInOverflow,
                 onRecommendClicked = onRecommendClicked,
+                showMerge = state.showMergeInOverflow,
                 showMergeSettings = state.manga.source == MERGED_SOURCE_ID,
                 onMergedSettingsClicked = onMergedSettingsClicked,
+                onMergeClicked = onMergeClicked,
                 // SY <--
                 actionModeCounter = chapters.count { it.selected },
                 onSelectAll = { onAllChapterSelected(true) },
@@ -405,6 +407,7 @@ private fun MangaScreenSmallImpl(
                             onEditCategory = onEditCategoryClicked,
                             // SY -->
                             onMergeClicked = onMergeClicked,
+                            showMergeButton = !state.showMergeInOverflow,
                             // SY <--
                         )
                     }
@@ -595,8 +598,10 @@ fun MangaScreenLargeImpl(
                     onEditInfoClicked = onEditInfoClicked,
                     showRecommends = state.showRecommendationsInOverflow,
                     onRecommendClicked = onRecommendClicked,
+                    showMerge = state.showMergeInOverflow,
                     showMergeSettings = state.manga.source == MERGED_SOURCE_ID,
                     onMergedSettingsClicked = onMergedSettingsClicked,
+                    onMergeClicked = onMergeClicked,
                     // SY <--
                     actionModeCounter = chapters.count { it.selected },
                     onSelectAll = { onAllChapterSelected(true) },
@@ -679,6 +684,7 @@ fun MangaScreenLargeImpl(
                         onEditCategory = onEditCategoryClicked,
                         // SY -->
                         onMergeClicked = onMergeClicked,
+                        showMergeButton = !state.showMergeInOverflow,
                         // SY <--
                     )
                     // SY -->

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaAppBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaAppBar.kt
@@ -55,6 +55,8 @@ fun MangaAppBar(
     onEditInfoClicked: () -> Unit,
     showRecommends: Boolean,
     onRecommendClicked: () -> Unit,
+    showMerge: Boolean,
+    onMergeClicked: () -> Unit,
     showMergeSettings: Boolean,
     onMergedSettingsClicked: () -> Unit,
     // SY <--
@@ -201,6 +203,15 @@ fun MangaAppBar(
                                         text = { Text(text = stringResource(R.string.action_migrate)) },
                                         onClick = {
                                             onMigrateClicked()
+                                            onDismissRequest()
+                                        },
+                                    )
+                                }
+                                if (onMergeClicked != null && showMerge) {
+                                    DropdownMenuItem(
+                                        text = { Text(text = stringResource(R.string.merge)) },
+                                        onClick = {
+                                            onMergeClicked()
                                             onDismissRequest()
                                         },
                                     )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -164,6 +164,7 @@ fun MangaActionRow(
     onEditCategory: (() -> Unit)?,
     // SY -->
     onMergeClicked: () -> Unit,
+    showMergeButton: Boolean,
     // SY <--
 ) {
     Row(modifier = modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp)) {
@@ -200,12 +201,15 @@ fun MangaActionRow(
             )
         }
         // SY -->
-        MangaActionButton(
-            title = stringResource(R.string.merge),
-            icon = Icons.Outlined.CallMerge,
-            color = defaultActionButtonColor,
-            onClick = onMergeClicked,
-        )
+        if (showMergeButton) {
+            MangaActionButton(
+                title = stringResource(R.string.merge),
+                icon = Icons.Outlined.CallMerge,
+                color = defaultActionButtonColor,
+                onClick = onMergeClicked,
+            )
+        }
+
         // SY <--
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -453,6 +453,8 @@ class PreferencesHelper(val context: Context) {
 
     fun recommendsInOverflow() = flowPrefs.getBoolean("recommends_in_overflow", false)
 
+    fun mergeInOverflow() = flowPrefs.getBoolean("merge_in_overflow", false)
+
     fun enhancedEHentaiView() = flowPrefs.getBoolean("enhanced_e_hentai_view", true)
 
     fun webtoonEnableZoomOut() = flowPrefs.getBoolean("webtoon_enable_zoom_out", false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaPresenter.kt
@@ -350,6 +350,7 @@ class MangaPresenter(
                                     meta = raiseMetadata(flatMetadata, source),
                                     mergedData = mergedData,
                                     showRecommendationsInOverflow = preferences.recommendsInOverflow().get(),
+                                    showMergeInOverflow = preferences.mergeInOverflow().get(),
                                     showMergeWithAnother = smartSearched,
                                     pagePreviewsState = if (source.getMainSource() is PagePreviewSource) {
                                         getPagePreviews(manga, source)
@@ -1539,6 +1540,7 @@ sealed class MangaScreenState {
         val meta: RaisedSearchMetadata?,
         val mergedData: MergedMangaData?,
         val showRecommendationsInOverflow: Boolean,
+        val showMergeInOverflow: Boolean,
         val showMergeWithAnother: Boolean,
         val pagePreviewsState: PagePreviewState,
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -61,6 +61,12 @@ class SettingsGeneralController : SettingsController() {
                 titleRes = R.string.put_recommends_in_overflow
                 summaryRes = R.string.put_recommends_in_overflow_summary
             }
+
+            switchPreference {
+                bindTo(preferences.mergeInOverflow())
+                titleRes = R.string.put_merge_in_overflow
+                summaryRes = R.string.put_merge_in_overflow_summary
+            }
         }
         // <-- EXH
     }

--- a/app/src/main/res/values-fr/strings_sy.xml
+++ b/app/src/main/res/values-fr/strings_sy.xml
@@ -167,6 +167,8 @@
     <string name="auto_solve_captchas_summary">Utilisez le solveur automatique ReCAPTCHA HAUTEMENT EXPÉRIMENTAL. Sera grisé s\'il n\'est pas pris en charge par votre appareil.</string>
     <string name="put_recommends_in_overflow">Afficher les Recommandations</string>
     <string name="put_recommends_in_overflow_summary">Met le bouton de recommandations dans le menu à déroulant de la page du manga</string>
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
 
     <!-- Library settings -->
     <string name="pref_sorting_settings">Paramètres de tri</string>

--- a/app/src/main/res/values-in/strings_sy.xml
+++ b/app/src/main/res/values-in/strings_sy.xml
@@ -174,7 +174,9 @@
     <string name="auto_solve_captchas_summary">Fitur ini SANGAT EKSPERIMENTAL. Akan berwarna abu-abu jika tidak didukung oleh perangkat Anda.</string>
     <string name="put_recommends_in_overflow">Rekomendasi di tombol overflow</string>
     <string name="put_recommends_in_overflow_summary">Letakkan tombol rekomendasi di tombol overflow alih-alih di halaman info manga</string>
-    
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
+
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">Navbar</string>
     <string name="pref_hide_updates_button">Tampilkan menu Pembaruan di navbar</string>

--- a/app/src/main/res/values-pt-rBR/strings_sy.xml
+++ b/app/src/main/res/values-pt-rBR/strings_sy.xml
@@ -173,6 +173,8 @@
     <string name="auto_solve_captchas_summary">Use o Resolve-ReCAPTCHA automático ALTAMENTE EXPERIMENTAL. Ficará cinza se não suportado por seu celular.</string>
     <string name="put_recommends_in_overflow">Recomendações no menu kebab</string>
     <string name="put_recommends_in_overflow_summary">Põe o botão Recomendações no menu flutuante em vez de na página do mangá</string>
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
     <string name="pref_hide_updates_button">Mover Botão Atualizações para a navegação</string>
     <string name="pref_hide_history_button">Mover Botão Histórico para a navegação</string>
     <string name="pref_show_bottom_bar_labels">Sempre mostrar rótulos na navegação</string>

--- a/app/src/main/res/values-ru/strings_sy.xml
+++ b/app/src/main/res/values-ru/strings_sy.xml
@@ -171,6 +171,8 @@
     <string name="auto_solve_captchas_summary">Использовать (ОЧЕНЬ ЭКСПЕРЕМЕНТАЛЬНО) автоматическое прохождение ReCAPTCHA. Если устройство не поддерживается, это меню будет выделено серым цветом.</string>
     <string name="put_recommends_in_overflow">Рекомендации в выпадающем меню</string>
     <string name="put_recommends_in_overflow_summary">Поместить кнопку «Рекомендации» в выпадающее меню вместо размещения на сведеньях серии</string>
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
 
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">Панель навигации</string>

--- a/app/src/main/res/values-zh-rCN/strings_sy.xml
+++ b/app/src/main/res/values-zh-rCN/strings_sy.xml
@@ -166,6 +166,8 @@
     <string name="auto_solve_captchas_summary">使用高度实验性的自动 ReCAPTCHA 解决器。如果您的设备不支持，则会显示为灰色。</string>
     <string name="put_recommends_in_overflow">在菜单显示推荐</string>
     <string name="put_recommends_in_overflow_summary">将推荐按钮放在弹出菜单而不是漫画页面</string>
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
 
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">导航栏</string>

--- a/app/src/main/res/values/strings_sy.xml
+++ b/app/src/main/res/values/strings_sy.xml
@@ -174,6 +174,8 @@
     <string name="auto_solve_captchas_summary">Use HIGHLY EXPERIMENTAL automatic ReCAPTCHA solver. Will be grayed out if unsupported by your device.</string>
     <string name="put_recommends_in_overflow">Recommendations in overflow</string>
     <string name="put_recommends_in_overflow_summary">Put the recommendations button in the overflow menu instead of on the manga page</string>
+    <string name="put_merge_in_overflow">Merge in overflow</string>
+    <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the manga page</string>
 
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">Navbar</string>


### PR DESCRIPTION
Added the ability to move the 'Merge' button on the manga details page to the overflow menu, addresses issue https://github.com/jobobby04/TachiyomiSY/issues/553

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
