### PR TITLE
Enabled ticks for reader sliders

### DIFF
--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -260,9 +260,10 @@
                                 android:id="@+id/page_slider_vert"
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
-                                android:rotation="90"
                                 android:layout_gravity="center"
-                                app:layout_constraintDimensionRatio="1:1" />
+                                android:rotation="90"
+                                app:layout_constraintDimensionRatio="1:1"
+                                app:tickVisible="true" />
 
                         </FrameLayout>
 
@@ -368,7 +369,8 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:maxHeight="?attr/actionBarSize"
-                        android:minHeight="?attr/actionBarSize" />
+                        android:minHeight="?attr/actionBarSize"
+                        app:tickVisible="true" />
 
                     <TextView
                         android:id="@+id/right_page_text"


### PR DESCRIPTION
Enabled the tickers for page sliders in reader mode, similar to ones in j2k, uses Material Design 3's default ones.

Images
Horizontal
![Horizontal](https://user-images.githubusercontent.com/25842958/184505021-0ce7a8d4-2565-4f26-88ba-b9ce94582a10.png) 

Vertical
![Vertical](https://user-images.githubusercontent.com/25842958/184505180-8e469f78-07da-43be-a319-d6e05e8975bc.png)
