### PR TITLE
Revert "Fixes the slider when in 2 page mode"

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1305,15 +1305,6 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
         // SY -->
         binding.abovePageText.text = currentPage
         binding.belowPageText.text = "${pages.size}"
-
-        if (hasExtraPage) {
-            binding.pageSlider.stepSize = 2f
-            binding.pageSliderVert.stepSize = 2f
-            if (binding.pageSliderVert.valueTo.toInt() % 2 == 1) {
-                binding.pageSlider.valueTo = binding.pageSlider.valueTo - 1
-                binding.pageSliderVert.valueTo = binding.pageSliderVert.valueTo - 1
-            }
-        }
         // SY <--
     }
 


### PR DESCRIPTION
Reverts the 2-page slider changes in jobobby04/TachiyomiSY#657 as it's causing crashes. Main issue is needing to consider horizontal/long pages, which displays as 1 page even in 2-page mode (as expected, but makes changing slider behaviour tricky).

Supersedes https://github.com/jobobby04/TachiyomiSY/pull/665