### PR TITLE
Remove suffix

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/GithubRelease.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/GithubRelease.kt
@@ -29,7 +29,7 @@ data class GithubRelease(
         }
 
         // SY <--
-        return assets.find { it.downloadLink.contains("TachiyomiSY$apkVariant-") }?.downloadLink
+        return assets.find { it.downloadLink.contains("TachiyomiSY$apkVariant") }?.downloadLink
             // SY -->
             ?: assets[0].downloadLink
     }


### PR DESCRIPTION
TachiyomiSY's (Preview Builds) APKs didn't have this suffix.
The code now causes the corresponding architecture impossible to find, which leads to downloading the APK for arm64 when updating from x86_64.