### PR TITLE
Bump xmlutil Version

### DIFF
--- a/gradle/kotlinx.versions.toml
+++ b/gradle/kotlinx.versions.toml
@@ -3,7 +3,7 @@ kotlin_version = "1.8.10"
 # TODO: 1.4.1 introduces an issue with cached serializers; see https://github.com/Kotlin/kotlinx.serialization/issues/2065
 # TODO: 1.5.0 introduces ExceptionInInitializerError crashes
 serialization_version = "1.4.0"
-xml_serialization_version = "0.84.3"
+xml_serialization_version = "0.85.0"
 
 [libraries]
 reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin_version" }


### PR DESCRIPTION
Use the newest Version of xmlutil. 
This will fix half of the Surrogate pair bug, but even in the newest version Characters between `0xE000` and `0xFFFD` will be replaced with NULL characters so disabling the creation of ComicInfo files until the next release of xmlutil were this new bug will be fixed may be advisible. 