### PR TITLE
fix ZipPageLoader not working for encrypted cbz archives

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
@@ -66,7 +66,7 @@ internal class ZipPageLoader(file: File) : PageLoader() {
         zip.setPassword(CbzCrypto.getDecryptedPasswordCbz())
 
         zip.fileHeaders.asSequence()
-            .filterNot { !it.isDirectory }
+            .filterNot { it.isDirectory }
             .forEach { entry ->
                 zip.extractFile(entry, tmpDir.absolutePath)
             }


### PR DESCRIPTION
`.filterNot` and `!it.isDirectory` were canceling each other out
