### PR TITLE
fixed encrypted sql database gets overwritten on sql-schema change

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppModule.kt
@@ -27,6 +27,7 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.source.AndroidSourceManager
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import eu.kanade.tachiyomi.util.SqlCipherHelper
 import eu.kanade.tachiyomi.util.storage.CbzCrypto
 import eu.kanade.tachiyomi.util.system.isDevFlavor
 import exh.eh.EHentaiUpdateHelper
@@ -82,7 +83,11 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingletonFactory<SqlDriver> {
             // SY -->
-            System.loadLibrary("sqlcipher")
+            if (securityPreferences.encryptDatabase().get()) {
+                System.loadLibrary("sqlcipher")
+                SqlCipherHelper.migrateDatabase(app)
+            }
+
             // SY <--
             AndroidSqliteDriver(
                 schema = Database.Schema,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/SqlCipherUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/SqlCipherUtil.kt
@@ -1,0 +1,103 @@
+package eu.kanade.tachiyomi.util
+
+import android.content.Context
+import eu.kanade.tachiyomi.util.storage.CbzCrypto
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import tachiyomi.data.Database
+
+private const val IMPLEMENTED_SCHEMA_VERSION = 28
+
+// SY -->
+object SqlCipherHelper {
+    fun migrateDatabase(context: Context) {
+        val databaseFile = context.getDatabasePath(CbzCrypto.DATABASE_NAME)
+        if (databaseFile.exists()) {
+            val database = SQLiteDatabase.openDatabase(
+                databaseFile.absolutePath,
+                CbzCrypto.getDecryptedPasswordSql(),
+                null,
+                SQLiteDatabase.OPEN_READWRITE,
+                null,
+                null,
+            )
+
+            database.use { db ->
+                val oldVersion = db.version
+                val newVersion = Database.Schema.version
+                if (Database.Schema.version != db.version) {
+                    if (newVersion > IMPLEMENTED_SCHEMA_VERSION) {
+                        throw IllegalStateException("Sql Cipher has not been configured for Database Schema version: $newVersion yet")
+                    }
+
+                    db.version = Database.Schema.version
+
+                    if (oldVersion <= 25 && newVersion > 25) {
+                        db.rawExecSQL("ALTER TABLE mangas ADD COLUMN calculate_interval INTEGER DEFAULT 0 NOT NULL")
+                    }
+
+                    if (oldVersion <= 26 && newVersion > 26) {
+                        db.rawExecSQL("ALTER TABLE eh_favorites RENAME TO eh_favorites_temp")
+                        db.rawExecSQL(
+                            """
+                            |CREATE TABLE eh_favorites (
+                            |    gid TEXT NOT NULL,
+                            |    token TEXT NOT NULL,
+                            |    title TEXT NOT NULL,
+                            |    category INTEGER NOT NULL,
+                            |    PRIMARY KEY (gid, token)
+                            |)
+                            """.trimMargin(),
+                        )
+                        db.rawExecSQL(
+                            """
+                            |INSERT INTO eh_favorites
+                            |SELECT gid, token, title, category
+                            |FROM eh_favorites_temp
+                            """.trimMargin(),
+                        )
+                        db.rawExecSQL(
+                            "DROP TABLE IF EXISTS eh_favorites_temp",
+                        )
+                        db.rawExecSQL(
+                            """
+                            |CREATE TABLE eh_favorites_alternatives (
+                            |    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            |    gid TEXT NOT NULL,
+                            |    token TEXT NOT NULL,
+                            |    otherGid TEXT NOT NULL,
+                            |    otherToken TEXT NOT NULL,
+                            |    FOREIGN KEY (gid, token) REFERENCES eh_favorites(gid, token)
+                            |)
+                            """.trimMargin(),
+                        )
+                        db.rawExecSQL("CREATE INDEX eh_favorites_alternatives_gid_token_index ON eh_favorites_alternatives(gid, token)")
+                        db.rawExecSQL("CREATE INDEX eh_favorites_alternatives_other_gid_token_index ON eh_favorites_alternatives(otherGid, otherToken)")
+                    }
+
+                    if (oldVersion <= 27 && newVersion > 27) {
+                        db.rawExecSQL("DROP INDEX IF EXISTS eh_favorites_alternatives_gid_token_index")
+                        db.rawExecSQL("DROP INDEX IF EXISTS eh_favorites_alternatives_other_gid_token_index")
+                        db.rawExecSQL("DROP TABLE IF EXISTS eh_favorites_alternatives")
+                        db.rawExecSQL(
+                            """
+                            |CREATE TABLE eh_favorites_alternatives (
+                            |    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            |    gid TEXT NOT NULL,
+                            |    token TEXT NOT NULL,
+                            |    otherGid TEXT NOT NULL,
+                            |    otherToken TEXT NOT NULL,
+                            |    UNIQUE (gid, token, otherGid, otherToken)
+                            |)
+                            """.trimMargin(),
+                        )
+                        db.rawExecSQL("CREATE INDEX eh_favorites_alternatives_gid_token_index ON eh_favorites_alternatives(gid, token)")
+                        db.rawExecSQL("CREATE INDEX eh_favorites_alternatives_other_gid_token_index ON eh_favorites_alternatives(otherGid, otherToken)")
+                    }
+
+
+                }
+            }
+        }
+    }
+}
+// SY <--


### PR DESCRIPTION
This is fundamentally an upstream issue and I'll open a new Issue on GitHub sometime this week, when I have a little more time.

The Database gets overwritten directly after being opened, even before `sqldelights` internal `onUpgrade` function gets called, which means that fixing this using sqldelight is not possible. 

This is why I copied the raw SQL from `DatabaseImpl.kt` and am executing it using `Sqlciphers` own functions for now. The draw back is that the SQL code must be copied from `DatabaseImpl.kt's` `migrate` function to `SqlCipherUtil` by hand, every time a new schema version is added.
