### PR TITLE
Shorter Chapter List in Reader

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/ChapterListDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ChapterListDialog.kt
@@ -1,7 +1,7 @@
 package eu.kanade.presentation.reader
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -40,7 +40,7 @@ fun ChapterListDialog(
     ) {
         LazyColumn(
             state = state,
-            modifier = Modifier.defaultMinSize(minHeight = 200.dp),
+            modifier = Modifier.heightIn(min = 200.dp, max = 500.dp),
             contentPadding = PaddingValues(vertical = 16.dp),
         ) {
             items(


### PR DESCRIPTION
make it shorter like before
<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td> <img src="https://github.com/jobobby04/TachiyomiSY/assets/16263232/ba674aeb-961e-4ecd-860a-1e4da02c85d0">
 <td> <img src="https://github.com/jobobby04/TachiyomiSY/assets/16263232/74406e5d-58f9-4a85-a60a-9d4677c03b1a">
</table>

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
