### PR TITLE
Fixed avif/encrypted thumbnails not loading

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -63,10 +63,14 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
 
         private fun isApplicable(source: BufferedSource): Boolean {
             // SY -->
-            val type = source.peek().inputStream().buffered().use {
-                if (CbzCrypto.detectCoverImageArchive(it)) return true
+            val streamBytes = ByteArray(128)
+            source.peek().inputStream().use { it.read(streamBytes, 0, streamBytes.size) }
+            val type = streamBytes.inputStream().buffered().use { stream ->
+                stream.mark(streamBytes.size)
+                if (CbzCrypto.detectCoverImageArchive(stream)) return true
+                stream.reset()
                 // SY <--
-                ImageUtil.findImageType(it)
+                ImageUtil.findImageType(stream)
             }
             return when (type) {
                 ImageUtil.ImageType.AVIF, ImageUtil.ImageType.JXL -> true

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -62,16 +62,14 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
         }
 
         private fun isApplicable(source: BufferedSource): Boolean {
-            // SY -->
-            val streamBytes = ByteArray(128)
-            source.peek().inputStream().use { it.read(streamBytes, 0, streamBytes.size) }
-            val type = streamBytes.inputStream().buffered().use { stream ->
-                stream.mark(streamBytes.size)
-                if (CbzCrypto.detectCoverImageArchive(stream)) return true
-                stream.reset()
-                // SY <--
+            val type = source.peek().inputStream().buffered().use { stream ->
                 ImageUtil.findImageType(stream)
             }
+            // SY -->
+            source.peek().inputStream().use { stream ->
+            if (CbzCrypto.detectCoverImageArchive(stream)) return true
+            }
+            // SY <--
             return when (type) {
                 ImageUtil.ImageType.AVIF, ImageUtil.ImageType.JXL -> true
                 ImageUtil.ImageType.HEIF -> Build.VERSION.SDK_INT < Build.VERSION_CODES.O


### PR DESCRIPTION
The old fix b3ab889 breaks encrypted thumbnails.

Buffered streams are not supported by zip4j. That's why it is necessary to open a fresh input stream before calling `CbzCrypto.detectCoverImageArchive`

I tested the fix with both avif and encrypted thumbnails