### PR TITLE
Add icon to jump directly to ExtensionDetailsScreen from SourcesScreen

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/model/Source.kt
+++ b/app/src/main/java/eu/kanade/domain/source/model/Source.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.drawable.toBitmap
 import eu.kanade.tachiyomi.extension.ExtensionManager
+import eu.kanade.tachiyomi.extension.model.Extension
 import tachiyomi.domain.source.model.Source
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -14,3 +15,14 @@ val Source.icon: ImageBitmap?
             ?.toBitmap()
             ?.asImageBitmap()
     }
+
+// AM (BROWSE) -->
+// Add an extra property to Source for it to get access to ExtensionManager
+val Source.installedExtension: Extension.Installed
+    get() {
+        return Injekt.get<ExtensionManager>()
+            .installedExtensionsFlow
+            .value
+            .find { ext -> ext.sources.any { it.id == id } }!!
+    }
+// <-- AM (BROWSE)

--- a/app/src/main/java/eu/kanade/domain/source/model/Source.kt
+++ b/app/src/main/java/eu/kanade/domain/source/model/Source.kt
@@ -18,11 +18,11 @@ val Source.icon: ImageBitmap?
 
 // AM (BROWSE) -->
 // Add an extra property to Source for it to get access to ExtensionManager
-val Source.installedExtension: Extension.Installed
+val Source.installedExtension: Extension.Installed?
     get() {
         return Injekt.get<ExtensionManager>()
             .installedExtensionsFlow
             .value
-            .find { ext -> ext.sources.any { it.id == id } }!!
+            .find { ext -> ext.sources.any { it.id == id } }
     }
 // <-- AM (BROWSE)

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -33,6 +33,8 @@ import eu.kanade.tachiyomi.ui.browse.extension.details.ExtensionDetailsScreen
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel.Listing
 import eu.kanade.tachiyomi.util.system.LocaleHelper
+import exh.source.EH_SOURCE_ID
+import exh.source.EXH_SOURCE_ID
 import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.domain.source.model.Pin
 import tachiyomi.domain.source.model.Source
@@ -211,8 +213,13 @@ private fun SourcePinButton(
 private fun SourceSettingsButton(
     source: Source,
 ) {
+    // Avoid E-Hentai & ExHentai which is built-in & not actually installed extensions
+    if (source.id == EH_SOURCE_ID || source.id == EXH_SOURCE_ID) return
     val navigator = LocalNavigator.currentOrThrow
-    IconButton(onClick = { navigator.push(ExtensionDetailsScreen(source.installedExtension.pkgName)) }) {
+    IconButton(onClick = {
+        if (source.installedExtension !== null)
+            navigator.push(ExtensionDetailsScreen(source.installedExtension!!.pkgName))
+    }) {
         Icon(
             imageVector = Icons.Outlined.Settings,
             tint = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.PushPin
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,7 +25,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.source.model.installedExtension
 import eu.kanade.presentation.browse.components.BaseSourceItem
+import eu.kanade.tachiyomi.ui.browse.extension.details.ExtensionDetailsScreen
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel.Listing
 import eu.kanade.tachiyomi.util.system.LocaleHelper
@@ -43,6 +48,7 @@ import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.presentation.core.theme.header
 import tachiyomi.presentation.core.util.plus
+import tachiyomi.source.local.LocalSource
 import tachiyomi.source.local.isLocal
 
 @Composable
@@ -52,6 +58,7 @@ fun SourcesScreen(
     onClickItem: (Source, Listing) -> Unit,
     onClickPin: (Source) -> Unit,
     onLongClickItem: (Source) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     when {
         state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
@@ -165,6 +172,13 @@ private fun SourceItem(
                 )
             }
             // SY <--
+            // AM (BROWSE) -->
+            if (source.id != LocalSource.ID) {
+                SourceSettingsButton(
+                    source = source,
+                )
+            }
+            // <-- AM (BROWSE)
         },
     )
 }
@@ -191,6 +205,22 @@ private fun SourcePinButton(
         )
     }
 }
+
+// AM (BROWSE) -->
+@Composable
+private fun SourceSettingsButton(
+    source: Source,
+) {
+    val navigator = LocalNavigator.currentOrThrow
+    IconButton(onClick = { navigator.push(ExtensionDetailsScreen(source.installedExtension.pkgName)) }) {
+        Icon(
+            imageVector = Icons.Outlined.Settings,
+            tint = MaterialTheme.colorScheme.primary,
+            contentDescription = stringResource(MR.strings.label_settings),
+        )
+    }
+}
+// <-- AM (BROWSE)
 
 @Composable
 fun SourceOptionsDialog(


### PR DESCRIPTION
Currently it's really difficult to jump between Sources & Extensions screen for example to remove the source you don't want.

* Add icon to jump directly to ExtensionDetailsScreen from SourcesScreen
* Avoid showing ExtensionDetailsScreen for E-Hentai & ExHentai which is built-in & not actually installed extensions

### Images
| Image 1 |
| ------- |
| ![](https://github.com/jobobby04/TachiyomiSY/assets/16017808/c74d4692-081e-412e-bba4-68d8f7487cf0) | 
