### PR TITLE
fix password protect downloads and copying ComicInfo files in LocalSource

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -673,10 +673,14 @@ class Downloader(
 
         tmpDir.filePath?.let { addPaddingToImage(File(it)) }
 
-        zip.addFiles(
-            tmpDir.listFiles()?.map { img -> img.filePath?.let { File(it) } },
-            zipParameters,
-        )
+        tmpDir.listFiles()?.map { img ->
+            zipParameters.fileNameInZip = img.name
+            zip.addStream(
+                img.openInputStream(),
+                zipParameters,
+            )
+        }
+
         zip.close()
 
         val realZip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
@@ -685,6 +689,7 @@ class Downloader(
                 it.copyTo(out)
             }
         }
+
         mangaDir.findFile("$dirname.cbz$TMP_DIR_SUFFIX")?.renameTo("$dirname.cbz")
         tmpDir.delete()
         zipFile.delete()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
-import android.os.Build
 import com.hippo.unifile.UniFile
 import eu.kanade.domain.chapter.model.toSChapter
 import eu.kanade.domain.manga.model.getComicInfo
@@ -14,6 +13,7 @@ import eu.kanade.tachiyomi.source.UnmeteredSource
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.storage.CbzCrypto
+import eu.kanade.tachiyomi.util.storage.CbzCrypto.addFilesToZip
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.DiskUtil.NOMEDIA_FILE
 import eu.kanade.tachiyomi.util.storage.saveTo
@@ -43,8 +43,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import logcat.LogPriority
-import net.lingala.zip4j.ZipFile
-import net.lingala.zip4j.model.ZipParameters
 import nl.adaptivity.xmlutil.serialization.XML
 import okhttp3.Response
 import tachiyomi.core.common.i18n.stringResource
@@ -66,7 +64,6 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.BufferedOutputStream
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
@@ -663,36 +660,15 @@ class Downloader(
         dirname: String,
         tmpDir: UniFile,
     ) {
-        val zipFile = File(context.externalCacheDir, "$dirname.cbz$TMP_DIR_SUFFIX")
-        val zip = ZipFile(zipFile)
-        val zipParameters = ZipParameters()
-
-        CbzCrypto.setZipParametersEncrypted(zipParameters)
-        zip.setPassword(CbzCrypto.getDecryptedPasswordCbz())
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) zip.charset = StandardCharsets.ISO_8859_1
-
         tmpDir.filePath?.let { addPaddingToImage(File(it)) }
 
-        tmpDir.listFiles()?.map { img ->
-            zipParameters.fileNameInZip = img.name
-            zip.addStream(
-                img.openInputStream(),
-                zipParameters,
-            )
-        }
-
-        zip.close()
-
-        val realZip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
-        realZip.openOutputStream().use { out ->
-            zipFile.inputStream().use {
-                it.copyTo(out)
-            }
+        tmpDir.listFiles()?.toList()?.let { files ->
+            mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")
+                ?.addFilesToZip(files, CbzCrypto.getDecryptedPasswordCbz())
         }
 
         mangaDir.findFile("$dirname.cbz$TMP_DIR_SUFFIX")?.renameTo("$dirname.cbz")
         tmpDir.delete()
-        zipFile.delete()
     }
 
     private fun addPaddingToImage(imageDir: File) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
@@ -37,10 +37,6 @@ internal class ZipPageLoader(file: File) : PageLoader() {
         }
 
     init {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            zip4j.charset = StandardCharsets.ISO_8859_1
-        }
-
         Zip4jFile(file).use { zip ->
             if (zip.isEncrypted) {
                 if (!CbzCrypto.checkCbzPassword(zip, CbzCrypto.getDecryptedPasswordCbz())) {

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/storage/CbzCrypto.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/storage/CbzCrypto.kt
@@ -3,7 +3,9 @@ package eu.kanade.tachiyomi.util.storage
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -11,9 +13,14 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import logcat.LogPriority
 import net.lingala.zip4j.ZipFile
+import net.lingala.zip4j.exception.ZipException
+import net.lingala.zip4j.io.inputstream.ZipInputStream
+import net.lingala.zip4j.io.outputstream.ZipOutputStream
+import net.lingala.zip4j.model.LocalFileHeader
 import net.lingala.zip4j.model.ZipParameters
 import net.lingala.zip4j.model.enums.AesKeyStrength
 import net.lingala.zip4j.model.enums.EncryptionMethod
+import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.injectLazy
 import java.io.ByteArrayInputStream
@@ -220,6 +227,133 @@ object CbzCrypto {
             stream.read(bytes, 0, bytes.size)
         }
         return String(bytes).contains(DEFAULT_COVER_NAME, ignoreCase = true)
+    }
+
+    fun UniFile.isEncryptedZip(): Boolean {
+        return try {
+            val stream = ZipInputStream(this.openInputStream())
+            stream.nextEntry
+            stream.close()
+            false
+        } catch (zipException: ZipException) {
+            if (zipException.type == ZipException.Type.WRONG_PASSWORD) {
+                true
+            } else throw zipException
+        }
+    }
+
+    fun UniFile.testCbzPassword(): Boolean {
+        return try {
+            val stream = ZipInputStream(this.openInputStream())
+            stream.setPassword(getDecryptedPasswordCbz())
+            stream.nextEntry
+            stream.close()
+            true
+        } catch (zipException: ZipException) {
+            if (zipException.type == ZipException.Type.WRONG_PASSWORD) {
+                false
+            } else throw zipException
+        }
+    }
+
+    fun UniFile.addStreamToZip(inputStream: InputStream, filename: String, password: CharArray? = null) {
+        val zipOutputStream =
+            if (password != null) ZipOutputStream(this.openOutputStream(), password)
+            else ZipOutputStream(this.openOutputStream())
+
+        val zipParameters = ZipParameters()
+        zipParameters.fileNameInZip = filename
+
+        if (password != null) setZipParametersEncrypted(zipParameters)
+        zipOutputStream.putNextEntry(zipParameters)
+
+        zipOutputStream.use { output ->
+            inputStream.use { input ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+
+    fun UniFile.addFilesToZip(files: List<UniFile>, password: CharArray? = null) {
+        val zipOutputStream =
+            if (password != null) ZipOutputStream(this.openOutputStream(), password)
+            else ZipOutputStream(this.openOutputStream())
+
+
+        files.forEach {
+            val zipParameters = ZipParameters()
+            if (password != null) setZipParametersEncrypted(zipParameters)
+            zipParameters.fileNameInZip = it.name
+
+            zipOutputStream.putNextEntry(zipParameters)
+
+            it.openInputStream().use { input ->
+                input.copyTo(zipOutputStream)
+            }
+            zipOutputStream.closeEntry()
+        }
+        zipOutputStream.close()
+    }
+
+    fun UniFile.getZipInputStream(filename: String): InputStream? {
+        val zipInputStream = ZipInputStream(this.openInputStream())
+        var fileHeader: LocalFileHeader?
+
+        if (this.isEncryptedZip()) zipInputStream.setPassword(getDecryptedPasswordCbz())
+
+        try {
+            while (run {
+                    fileHeader = zipInputStream.nextEntry
+                    fileHeader != null
+                }) {
+                if (fileHeader?.fileName == filename) return zipInputStream
+            }
+
+        } catch (zipException: ZipException) {
+            if (zipException.type == ZipException.Type.WRONG_PASSWORD) {
+                logcat(LogPriority.WARN) {
+                    "Wrong CBZ archive password for: ${this.name} in: ${this.parentFile?.name}"
+                }
+            } else throw zipException
+        }
+        return null
+    }
+    fun UniFile.getCoverStreamFromZip(): InputStream? {
+        val zipInputStream = ZipInputStream(this.openInputStream())
+        var fileHeader: LocalFileHeader?
+        val fileHeaderList: MutableList<LocalFileHeader?> = mutableListOf()
+
+        if (this.isEncryptedZip()) zipInputStream.setPassword(getDecryptedPasswordCbz())
+
+        try {
+            while (run {
+                    fileHeader = zipInputStream.nextEntry
+                    fileHeader != null
+                }) {
+                fileHeaderList.add(fileHeader)
+            }
+
+            var coverHeader = fileHeaderList
+                .mapNotNull { it }
+                .sortedWith { f1, f2 -> f1.fileName.compareToCaseInsensitiveNaturalOrder(f2.fileName) }
+                .find { !it.isDirectory && ImageUtil.isImage(it.fileName) }
+
+
+            val coverStream = coverHeader?.fileName?.let { this.getZipInputStream(it) }
+            if (coverStream != null) {
+                if (!ImageUtil.isImage(coverHeader?.fileName) { coverStream }) coverHeader = null
+            }
+            return coverHeader?.fileName?.let { getZipInputStream(it) }
+
+        } catch (zipException: ZipException) {
+            if (zipException.type == ZipException.Type.WRONG_PASSWORD) {
+                logcat(LogPriority.WARN) {
+                    "Wrong CBZ archive password for: ${this.name} in: ${this.parentFile?.name}"
+                }
+                return null
+            } else throw zipException
+        }
     }
 }
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -245,7 +245,7 @@ actual class LocalSource(
                     if (copiedFile != null && copiedFile.name != COMIC_INFO_ARCHIVE) {
                         setMangaDetailsFromComicInfoFile(copiedFile.openInputStream(), manga)
                     } else if (copiedFile != null && copiedFile.name == COMIC_INFO_ARCHIVE) {
-                        val comicInfoArchive = ZipFile(copiedFile.filePath)
+                        val comicInfoArchive = ZipFile(tempFileManager.createTempFile(copiedFile))
                         comicInfoArchive.setPassword(CbzCrypto.getDecryptedPasswordCbz())
                         val comicInfoEntry = comicInfoArchive.fileHeaders.firstOrNull { it.fileName == COMIC_INFO_FILE }
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -301,7 +301,7 @@ actual class LocalSource(
         return null
     }
 
-    private fun copyComicInfoFile(comicInfoFileStream: InputStream, mangaDir: UniFile): File {
+    private fun copyComicInfoFile(comicInfoFileStream: InputStream, mangaDir: UniFile): File? {
         // SY -->
         if (
             CbzCrypto.getPasswordProtectDlPref() &&
@@ -326,7 +326,7 @@ actual class LocalSource(
             }
             zipEncryptedFile.delete()
 
-            return zipEncrypted.file
+            return realZipEncrypted.filePath?.let { File(it) }
         } else {
             return File("${mangaDir.filePath}/$COMIC_INFO_FILE").apply {
                 // SY <--


### PR DESCRIPTION
fixes #1076

Trying to access the image files directly causes access denied errors, switching to streams fixes this.