### PR TITLE
Make manga page preview row count configurable

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -46,6 +46,8 @@ class UiPreferences(
 
     fun mergeInOverflow() = preferenceStore.getBoolean("merge_in_overflow", true)
 
+    fun previewsRowCount() = preferenceStore.getInt("pref_previews_row_count", 4)
+
     fun useNewSourceNavigation() = preferenceStore.getBoolean("use_new_source_navigation", true)
 
     fun bottomBarLabels() = preferenceStore.getBoolean("pref_show_bottom_bar_labels", true)

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -150,6 +150,7 @@ fun MangaScreen(
     onMergeWithAnotherClicked: () -> Unit,
     onOpenPagePreview: (Int) -> Unit,
     onMorePreviewsClicked: () -> Unit,
+    previewsRowCount: Int,
     // SY <--
 
     // For bottom action menu
@@ -208,6 +209,7 @@ fun MangaScreen(
             onMergeWithAnotherClicked = onMergeWithAnotherClicked,
             onOpenPagePreview = onOpenPagePreview,
             onMorePreviewsClicked = onMorePreviewsClicked,
+            previewsRowCount = previewsRowCount,
             // SY <--
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
@@ -253,6 +255,7 @@ fun MangaScreen(
             onMergeWithAnotherClicked = onMergeWithAnotherClicked,
             onOpenPagePreview = onOpenPagePreview,
             onMorePreviewsClicked = onMorePreviewsClicked,
+            previewsRowCount = previewsRowCount,
             // SY <--
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
@@ -308,6 +311,7 @@ private fun MangaScreenSmallImpl(
     onMergeWithAnotherClicked: () -> Unit,
     onOpenPagePreview: (Int) -> Unit,
     onMorePreviewsClicked: () -> Unit,
+    previewsRowCount: Int,
     // SY <--
 
     // For bottom action menu
@@ -544,13 +548,14 @@ private fun MangaScreenSmallImpl(
                         }
                     }
 
-                    if (state.pagePreviewsState !is PagePreviewState.Unused) {
+                    if (state.pagePreviewsState !is PagePreviewState.Unused && previewsRowCount > 0) {
                         PagePreviewItems(
                             pagePreviewState = state.pagePreviewsState,
                             onOpenPage = onOpenPagePreview,
                             onMorePreviewsClicked = onMorePreviewsClicked,
                             maxWidth = maxWidth,
-                            setMaxWidth = { maxWidth = it }
+                            setMaxWidth = { maxWidth = it },
+                            rowCount = previewsRowCount,
                         )
                     }
                     // SY <--
@@ -632,6 +637,7 @@ fun MangaScreenLargeImpl(
     onMergeWithAnotherClicked: () -> Unit,
     onOpenPagePreview: (Int) -> Unit,
     onMorePreviewsClicked: () -> Unit,
+    previewsRowCount: Int,
     // SY <--
 
     // For bottom action menu
@@ -832,11 +838,12 @@ fun MangaScreenLargeImpl(
                                 onMergeWithAnotherClicked = onMergeWithAnotherClicked,
                             )
                         }
-                        if (state.pagePreviewsState !is PagePreviewState.Unused) {
+                        if (state.pagePreviewsState !is PagePreviewState.Unused && previewsRowCount > 0) {
                             PagePreviews(
                                 pagePreviewState = state.pagePreviewsState,
                                 onOpenPage = onOpenPagePreview,
                                 onMorePreviewsClicked = onMorePreviewsClicked,
+                                rowCount = previewsRowCount,
                             )
                         }
                         // SY <--

--- a/app/src/main/java/eu/kanade/presentation/manga/components/PagePreviews.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/PagePreviews.kt
@@ -102,6 +102,7 @@ fun PagePreviews(
     pagePreviewState: PagePreviewState,
     onOpenPage: (Int) -> Unit,
     onMorePreviewsClicked: () -> Unit,
+    rowCount: Int,
 ) {
     Column(Modifier.fillMaxWidth()) {
         var maxWidth by remember {
@@ -113,7 +114,7 @@ fun PagePreviews(
             }
             pagePreviewState is PagePreviewState.Success -> {
                 val itemPerRowCount = (maxWidth / 120.dp).floor()
-                pagePreviewState.pagePreviews.take(4 * itemPerRowCount).chunked(itemPerRowCount).forEach {
+                pagePreviewState.pagePreviews.take(rowCount * itemPerRowCount).chunked(itemPerRowCount).forEach {
                     PagePreviewRow(
                         onOpenPage = onOpenPage,
                         items = remember(it) { it.toImmutableList() }
@@ -132,7 +133,8 @@ fun LazyListScope.PagePreviewItems(
     onOpenPage: (Int) -> Unit,
     onMorePreviewsClicked: () -> Unit,
     maxWidth: Dp,
-    setMaxWidth: (Dp) -> Unit
+    setMaxWidth: (Dp) -> Unit,
+    rowCount: Int,
 ) {
     when {
         pagePreviewState is PagePreviewState.Loading || maxWidth == Dp.Hairline -> {
@@ -148,7 +150,7 @@ fun LazyListScope.PagePreviewItems(
             items(
                 key = { "${MangaScreenItem.CHAPTER_PREVIEW_ROW}-$it" },
                 contentType = { MangaScreenItem.CHAPTER_PREVIEW_ROW },
-                items = pagePreviewState.pagePreviews.take(4 * itemPerRowCount).chunked(itemPerRowCount),
+                items = pagePreviewState.pagePreviews.take(rowCount * itemPerRowCount).chunked(itemPerRowCount),
             ) {
                 PagePreviewRow(
                     onOpenPage = onOpenPage,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -157,6 +157,8 @@ object SettingsAppearanceScreen : SearchableSettings {
     // SY -->
     @Composable
     fun getForkGroup(uiPreferences: UiPreferences): Preference.PreferenceGroup {
+        val previewsRowCount by uiPreferences.previewsRowCount().collectAsState()
+
         return Preference.PreferenceGroup(
             stringResource(SYMR.strings.pref_category_fork),
             preferenceItems = persistentListOf(
@@ -173,6 +175,20 @@ object SettingsAppearanceScreen : SearchableSettings {
                     pref = uiPreferences.mergeInOverflow(),
                     title = stringResource(SYMR.strings.put_merge_in_overflow),
                     subtitle = stringResource(SYMR.strings.put_merge_in_overflow_summary),
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = previewsRowCount,
+                    title = stringResource(SYMR.strings.pref_previews_row_count),
+                    subtitle = if (previewsRowCount > 0) stringResource(
+                        SYMR.strings.pref_previews_row_count_value,
+                        previewsRowCount,
+                    ) else stringResource(MR.strings.disabled),
+                    min = 0,
+                    max = 10,
+                    onValueChanged = {
+                        uiPreferences.previewsRowCount().set(it)
+                        true
+                    },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
+import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
@@ -179,8 +180,9 @@ object SettingsAppearanceScreen : SearchableSettings {
                 Preference.PreferenceItem.SliderPreference(
                     value = previewsRowCount,
                     title = stringResource(SYMR.strings.pref_previews_row_count),
-                    subtitle = if (previewsRowCount > 0) stringResource(
-                        SYMR.strings.pref_previews_row_count_value,
+                    subtitle = if (previewsRowCount > 0) pluralStringResource(
+                        SYMR.plurals.row_count,
+                        previewsRowCount,
                         previewsRowCount,
                     ) else stringResource(MR.strings.disabled),
                     min = 0,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -23,8 +23,10 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import eu.kanade.core.preference.asState
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.components.NavigatorAdaptiveSheet
 import eu.kanade.presentation.manga.ChapterSettingsDialog
@@ -115,6 +117,12 @@ class MangaScreen(
         val successState = state as MangaScreenModel.State.Success
         val isHttpSource = remember { successState.source is HttpSource }
 
+        // SY -->
+        val previewsRowCount by remember {
+            Injekt.get<UiPreferences>().previewsRowCount().asState(scope)
+        }
+        // SY <--
+
         LaunchedEffect(successState.manga, screenModel.source) {
             if (isHttpSource) {
                 try {
@@ -197,6 +205,7 @@ class MangaScreen(
             onEditFetchIntervalClicked = screenModel::showSetFetchIntervalDialog.takeIf {
                 successState.manga.favorite
             },
+            previewsRowCount = previewsRowCount,
             // SY -->
             onMigrateClicked = { migrateManga(navigator, screenModel.manga!!) }.takeIf { successState.manga.favorite },
             onMetadataViewerClicked = { openMetadataViewer(navigator, successState.manga) },

--- a/i18n-sy/src/commonMain/resources/MR/base/plurals.xml
+++ b/i18n-sy/src/commonMain/resources/MR/base/plurals.xml
@@ -71,4 +71,9 @@
         <item quantity="one">%1$d second ago</item>
         <item quantity="other">%1$d seconds ago</item>
     </plurals>
+
+    <plurals name="row_count">
+        <item quantity="one">%d row</item>
+        <item quantity="other">%d rows</item>
+    </plurals>
 </resources>

--- a/i18n-sy/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n-sy/src/commonMain/resources/MR/base/strings.xml
@@ -168,6 +168,8 @@
     <string name="put_recommends_in_overflow_summary">Put the recommendations button in the overflow menu instead of on the entry page</string>
     <string name="put_merge_in_overflow">Merge in overflow</string>
     <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the entry page</string>
+    <string name="pref_previews_row_count">Previews row count</string>
+    <string name="pref_previews_row_count_value">%d rows</string>
 
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">Navbar</string>

--- a/i18n-sy/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n-sy/src/commonMain/resources/MR/base/strings.xml
@@ -169,7 +169,6 @@
     <string name="put_merge_in_overflow">Merge in overflow</string>
     <string name="put_merge_in_overflow_summary">Put the merge button in the overflow menu instead of on the entry page</string>
     <string name="pref_previews_row_count">Previews row count</string>
-    <string name="pref_previews_row_count_value">%d rows</string>
 
     <!-- Appearance Settings -->
     <string name="pref_category_navbar">Navbar</string>


### PR DESCRIPTION
Closes #643 

Add a new appearance setting for the manga page preview row count. Allows between 0 (disabled) and 10 rows.

### Screenshots

| Default (4 rows) | Disabled |
| ------- | ------- |
| ![](https://github.com/jobobby04/TachiyomiSY/assets/25001812/ea909df7-a725-4bce-bd59-0142ca99bbfe)  | ![](https://github.com/jobobby04/TachiyomiSY/assets/25001812/4692b3e5-e0a0-4780-b1b0-282d77d0b286) | 
| ![](https://github.com/jobobby04/TachiyomiSY/assets/25001812/c972db58-6e3d-4543-8b62-4879e236e23f)| ![](https://github.com/jobobby04/TachiyomiSY/assets/25001812/172ead1b-25c2-47f7-bf87-c259081da5b3) |