### PR TITLE
Add option to reset custom manga info

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -239,6 +239,7 @@ fun LibraryBottomActionMenu(
     onClickCleanTitles: (() -> Unit)?,
     onClickMigrate: (() -> Unit)?,
     onClickAddToMangaDex: (() -> Unit)?,
+    onClickResetInfo: (() -> Unit)?,
     // SY <--
     modifier: Modifier = Modifier,
 ) {
@@ -267,7 +268,7 @@ fun LibraryBottomActionMenu(
                 }
             }
             // SY -->
-            val showOverflow = onClickCleanTitles != null || onClickAddToMangaDex != null
+            val showOverflow = onClickCleanTitles != null || onClickAddToMangaDex != null || onClickResetInfo != null
             val configuration = LocalConfiguration.current
             val moveMarkPrev = remember { !configuration.isTabletUi() }
             var overFlowOpen by remember { mutableStateOf(false) }
@@ -362,6 +363,12 @@ fun LibraryBottomActionMenu(
                             DropdownMenuItem(
                                 text = { Text(stringResource(SYMR.strings.mangadex_add_to_follows)) },
                                 onClick = onClickAddToMangaDex,
+                            )
+                        }
+                        if (onClickResetInfo != null) {
+                            DropdownMenuItem(
+                                text = { Text(text = stringResource(SYMR.strings.reset_info)) },
+                                onClick = onClickResetInfo,
                             )
                         }
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -750,6 +750,24 @@ class LibraryScreenModel(
             clearSelection()
         }
     }
+
+    fun resetInfo() {
+        state.value.selection.fastForEach { (manga) ->
+            val mangaInfo = CustomMangaInfo(
+                id = manga.id,
+                title = manga.ogTitle,
+                author = manga.ogAuthor,
+                artist = manga.ogArtist,
+                thumbnailUrl = manga.ogThumbnailUrl,
+                description = manga.ogDescription,
+                genre = manga.ogGenre,
+                status = manga.ogStatus,
+            )
+
+            setCustomMangaInfo.set(mangaInfo)
+        }
+        clearSelection()
+    }
     // SY <--
 
     /**
@@ -1335,6 +1353,18 @@ class LibraryScreenModel(
 
         val showAddToMangadex: Boolean by lazy {
             selection.any { it.manga.source in mangaDexSourceIds }
+        }
+
+        val showResetInfo: Boolean by lazy {
+            selection.fastAny { (manga) ->
+                manga.title != manga.ogTitle ||
+                    manga.author != manga.ogAuthor ||
+                    manga.artist != manga.ogArtist ||
+                    manga.thumbnailUrl != manga.ogThumbnailUrl ||
+                    manga.description != manga.ogDescription ||
+                    manga.genre != manga.ogGenre ||
+                    manga.status != manga.ogStatus
+            }
         }
         // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -755,13 +755,13 @@ class LibraryScreenModel(
         state.value.selection.fastForEach { (manga) ->
             val mangaInfo = CustomMangaInfo(
                 id = manga.id,
-                title = manga.ogTitle,
-                author = manga.ogAuthor,
-                artist = manga.ogArtist,
-                thumbnailUrl = manga.ogThumbnailUrl,
-                description = manga.ogDescription,
-                genre = manga.ogGenre,
-                status = manga.ogStatus,
+                title = null,
+                author = null,
+                artist = null,
+                thumbnailUrl = null,
+                description = null,
+                genre = null,
+                status = null,
             )
 
             setCustomMangaInfo.set(mangaInfo)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -205,6 +205,7 @@ object LibraryTab : Tab {
                         }
                     },
                     onClickAddToMangaDex = screenModel::syncMangaToDex.takeIf { state.showAddToMangadex },
+                    onClickResetInfo = screenModel::resetInfo.takeIf { state.showResetInfo },
                     // SY <--
                 )
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -201,6 +201,7 @@ private fun onViewCreated(manga: Manga, context: Context, binding: EditMangaDial
     binding.mangaGenresTags.clearFocus()
 
     binding.resetTags.setOnClickListener { resetTags(manga, binding, scope) }
+    binding.resetInfo.setOnClickListener { resetInfo(manga, binding, scope) }
 }
 
 private fun resetTags(manga: Manga, binding: EditMangaDialogBinding, scope: CoroutineScope) {
@@ -215,6 +216,16 @@ private fun loadCover(manga: Manga, context: Context, binding: EditMangaDialogBi
     binding.mangaCover.load(manga) {
         transformations(RoundedCornersTransformation(4.dpToPx.toFloat()))
     }
+}
+
+
+private fun resetInfo(manga: Manga, binding: EditMangaDialogBinding, scope: CoroutineScope) {
+    binding.title.setText("")
+    binding.mangaAuthor.setText("")
+    binding.mangaArtist.setText("")
+    binding.thumbnailUrl.setText("")
+    binding.mangaDescription.setText("")
+    resetTags(manga, binding, scope)
 }
 
 private fun ChipGroup.setChips(items: List<String>, scope: CoroutineScope) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -218,7 +218,6 @@ private fun loadCover(manga: Manga, context: Context, binding: EditMangaDialogBi
     }
 }
 
-
 private fun resetInfo(manga: Manga, binding: EditMangaDialogBinding, scope: CoroutineScope) {
     binding.title.setText("")
     binding.mangaAuthor.setText("")

--- a/app/src/main/res/layout/edit_manga_dialog.xml
+++ b/app/src/main/res/layout/edit_manga_dialog.xml
@@ -139,6 +139,16 @@
         android:text="@string/reset_tags"
         android:textAllCaps="false" />
 
+    <Button
+        android:id="@+id/reset_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/reset_info"
+        android:textAllCaps="false" />
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"

--- a/i18n-sy/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n-sy/src/commonMain/resources/MR/base/strings.xml
@@ -350,6 +350,7 @@
     <!-- Entry Info Edit -->
     <string name="reset_tags">Reset Tags</string>
     <string name="add_tag">Add Tag</string>
+    <string name="reset_info">Reset Info</string>
     <string name="title_hint">Title: %1$s</string>
     <string name="description_hint">Description: %1$s</string>
     <string name="author_hint">Author: %1$s</string>


### PR DESCRIPTION
- Add a button to the "Edit info" modal to be able to reset custom manga info.
- Add a button in the bottom bar in the library to be able to reset custom manga info for multiple galleries.

![Screenshot_20240316_230635_result](https://github.com/jobobby04/TachiyomiSY/assets/25001812/18830598-28d9-4285-ad19-4135fa857fe9)

| Before | After |
| ------ |  ----- |
| ![Screenshot_20240316_230526_result](https://github.com/jobobby04/TachiyomiSY/assets/25001812/121646d6-59de-4414-8194-cc35ea51ca33) | ![Screenshot_20240316_230535_result](https://github.com/jobobby04/TachiyomiSY/assets/25001812/c48b60b9-8ab5-4783-a228-344ce3f710d2) |
