### PR TITLE
fix: sync on library update trigger.

### DIFF
--- a/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
@@ -73,7 +73,6 @@ class SyncPreferences(
             syncOnChapterOpen = preferenceStore.getBoolean("sync_on_chapter_open", false).get(),
             syncOnAppStart = preferenceStore.getBoolean("sync_on_app_start", false).get(),
             syncOnAppResume = preferenceStore.getBoolean("sync_on_app_resume", false).get(),
-            syncOnLibraryUpdate = preferenceStore.getBoolean("sync_on_library_update", false).get(),
         )
     }
 
@@ -86,7 +85,5 @@ class SyncPreferences(
             .set(syncTriggerOptions.syncOnAppStart)
         preferenceStore.getBoolean("sync_on_app_resume", false)
             .set(syncTriggerOptions.syncOnAppResume)
-        preferenceStore.getBoolean("sync_on_library_update", false)
-            .set(syncTriggerOptions.syncOnLibraryUpdate)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -817,19 +817,11 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                 KEY_GROUP_EXTRA to groupExtra,
                 // SY <--
             )
-            val request = OneTimeWorkRequestBuilder<LibraryUpdateJob>()
-                .addTag(TAG)
-                .addTag(WORK_NAME_MANUAL)
-                .setInputData(inputData)
-                .build()
-            wm.enqueueUniqueWork(WORK_NAME_MANUAL, ExistingWorkPolicy.KEEP, request)
 
             val syncPreferences: SyncPreferences = Injekt.get()
 
-            // Only proceed with SyncDataJob if sync is enabled and the specific sync on library update flag is set
-            val syncTriggerOpt = syncPreferences.getSyncTriggerOptions()
-            if (syncPreferences.isSyncEnabled() && syncTriggerOpt.syncOnLibraryUpdate
-            ) {
+            // Always sync the data before library update if syncing is enabled.
+            if (syncPreferences.isSyncEnabled()) {
                 // Check if SyncDataJob is already running
                 if (wm.isRunning(SyncDataJob.TAG_MANUAL)) {
                     // SyncDataJob is already running
@@ -842,7 +834,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                     .build()
 
                 // Chain SyncDataJob to run before LibraryUpdateJob
-                val inputData = workDataOf(KEY_CATEGORY to category?.id)
                 val libraryUpdateJob = OneTimeWorkRequestBuilder<LibraryUpdateJob>()
                     .addTag(TAG)
                     .addTag(WORK_NAME_MANUAL)
@@ -853,7 +844,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                     .then(libraryUpdateJob)
                     .enqueue()
             } else {
-                val inputData = workDataOf(KEY_CATEGORY to category?.id)
                 val request = OneTimeWorkRequestBuilder<LibraryUpdateJob>()
                     .addTag(TAG)
                     .addTag(WORK_NAME_MANUAL)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/SyncTriggerOptions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/SyncTriggerOptions.kt
@@ -9,21 +9,18 @@ data class SyncTriggerOptions(
     val syncOnChapterOpen: Boolean = false,
     val syncOnAppStart: Boolean = false,
     val syncOnAppResume: Boolean = false,
-    val syncOnLibraryUpdate: Boolean = false,
 ) {
     fun asBooleanArray() = booleanArrayOf(
         syncOnChapterRead,
         syncOnChapterOpen,
         syncOnAppStart,
         syncOnAppResume,
-        syncOnLibraryUpdate,
     )
 
     fun anyEnabled() = syncOnChapterRead ||
         syncOnChapterOpen ||
         syncOnAppStart ||
-        syncOnAppResume ||
-        syncOnLibraryUpdate
+        syncOnAppResume
 
     companion object {
         val mainOptions = persistentListOf(
@@ -47,11 +44,6 @@ data class SyncTriggerOptions(
                 getter = SyncTriggerOptions::syncOnAppResume,
                 setter = { options, enabled -> options.copy(syncOnAppResume = enabled) },
             ),
-            Entry(
-                label = MR.strings.sync_on_library_update,
-                getter = SyncTriggerOptions::syncOnLibraryUpdate,
-                setter = { options, enabled -> options.copy(syncOnLibraryUpdate = enabled) },
-            ),
         )
 
         fun fromBooleanArray(array: BooleanArray) = SyncTriggerOptions(
@@ -59,7 +51,6 @@ data class SyncTriggerOptions(
             syncOnChapterOpen = array[1],
             syncOnAppStart = array[2],
             syncOnAppResume = array[3],
-            syncOnLibraryUpdate = array[4],
         )
     }
 

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -591,7 +591,6 @@
     <string name="sync_on_chapter_open">Sync on Chapter Open</string>
     <string name="sync_on_app_start">Sync on App Start</string>
     <string name="sync_on_app_resume">Sync on App Resume</string>
-    <string name="sync_on_library_update">Sync on Library Update</string>
     <string name="sync_library">Sync library</string>
 
       <!-- Advanced section -->


### PR DESCRIPTION
So I removed the trigger for library update from the options, instead if sync is enabled it should always sync first before updating library.

Manga chapter is reshuffled like below:
(a simple refresh on the manga should fix it usually)

![image](https://github.com/jobobby04/TachiyomiSY/assets/41852205/8c65e2d6-9fb5-4c3b-a490-67f3a0bcab0a)
![image](https://github.com/jobobby04/TachiyomiSY/assets/41852205/0ce9afe5-5cad-4fab-bbfc-e27fd7d89111)


A little bit context:
![image](https://github.com/jobobby04/TachiyomiSY/assets/41852205/00f12024-8cab-4f57-b7a5-f39a1cc266f0)



Also syncing before library update should help with sources not being hit too much, since if main device for example have the latest data it should just send that instead of each devices trying to get the latest data from the sources, instead of 3 devices doing global update, it should be 1 device and the rest of them get the data from that device. 