### PR TITLE
chore: sync clean ups

### DIFF
--- a/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
@@ -53,6 +53,11 @@ class SyncPreferences(
             appSettings = preferenceStore.getBoolean("appSettings", true).get(),
             sourceSettings = preferenceStore.getBoolean("sourceSettings", true).get(),
             privateSettings = preferenceStore.getBoolean("privateSettings", true).get(),
+
+            // SY -->
+            customInfo = preferenceStore.getBoolean("customInfo", true).get(),
+            readEntries = preferenceStore.getBoolean("readEntries", true).get()
+            // SY <--
         )
     }
 
@@ -65,6 +70,11 @@ class SyncPreferences(
         preferenceStore.getBoolean("appSettings", true).set(syncSettings.appSettings)
         preferenceStore.getBoolean("sourceSettings", true).set(syncSettings.sourceSettings)
         preferenceStore.getBoolean("privateSettings", true).set(syncSettings.privateSettings)
+
+        // SY -->
+        preferenceStore.getBoolean("customInfo", true).set(syncSettings.customInfo)
+        preferenceStore.getBoolean("readEntries", true).set(syncSettings.readEntries)
+        // SY <--
     }
 
     fun getSyncTriggerOptions(): SyncTriggerOptions {

--- a/app/src/main/java/eu/kanade/domain/sync/models/SyncSettings.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/models/SyncSettings.kt
@@ -9,4 +9,9 @@ data class SyncSettings(
     val appSettings: Boolean = true,
     val sourceSettings: Boolean = true,
     val privateSettings: Boolean = false,
+
+    // SY -->
+    val customInfo: Boolean = true,
+    val readEntries: Boolean = true
+    // SY <--
 )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
@@ -123,6 +123,11 @@ private class SyncSettingsSelectorModel(
                 appSettings = syncSettings.appSettings,
                 sourceSettings = syncSettings.sourceSettings,
                 privateSettings = syncSettings.privateSettings,
+
+                // SY -->
+                customInfo = syncSettings.customInfo,
+                readEntries = syncSettings.readEntries,
+                // SY <--
             )
         }
 
@@ -136,6 +141,11 @@ private class SyncSettingsSelectorModel(
                 appSettings = backupOptions.appSettings,
                 sourceSettings = backupOptions.sourceSettings,
                 privateSettings = backupOptions.privateSettings,
+
+                // SY -->
+                customInfo = backupOptions.customInfo,
+                readEntries = backupOptions.readEntries,
+                // SY <--
             )
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -88,6 +88,11 @@ class SyncManager(
             appSettings = syncOptions.appSettings,
             sourceSettings = syncOptions.sourceSettings,
             privateSettings = syncOptions.privateSettings,
+
+            // SY -->
+            customInfo = syncOptions.customInfo,
+            readEntries = syncOptions.readEntries,
+            // SY <--
         )
         val backup = Backup(
             backupManga = backupCreator.backupMangas(databaseManga, backupOptions),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -420,8 +420,6 @@ class GoogleDriveService(private val context: Context) {
             // Save the new access token
             syncPreferences.googleDriveAccessToken().set(newAccessToken)
             setupGoogleDriveService(newAccessToken, credential.refreshToken)
-            this@GoogleDriveService
-                .logcat(LogPriority.DEBUG) { "Google Access token refreshed old: $accessToken new: $newAccessToken" }
         } catch (e: TokenResponseException) {
             if (e.details.error == "invalid_grant") {
                 // The refresh token is invalid, prompt the user to sign in again

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveSyncService.kt
@@ -392,7 +392,6 @@ class GoogleDriveService(private val context: Context) {
     }
     internal suspend fun refreshToken() = withIOContext {
         val refreshToken = syncPreferences.googleDriveRefreshToken().get()
-        val accessToken = syncPreferences.googleDriveAccessToken().get()
 
         val jsonFactory: JsonFactory = JacksonFactory.getDefaultInstance()
         val secrets = GoogleClientSecrets.load(
@@ -411,8 +410,6 @@ class GoogleDriveService(private val context: Context) {
         }
 
         credential.refreshToken = refreshToken
-
-        this@GoogleDriveService.logcat(LogPriority.DEBUG) { "Refreshing access token with: $refreshToken" }
 
         try {
             credential.refreshToken()


### PR DESCRIPTION
Small clean up, removed logging google drive token, we don't need to log it.

Also fixed the `customInfo` and `readEntries` It wasn't taking it into account, so when user disables it, it will still sync it regardless because it's `true` by default in the `backupOptions`, and fixed the check mark not being persisted always getting reset when we go back into it will be marked as checked. Basically was missing SY stuff.  