### PR TITLE
Update LewdMangaChecker.kt to also filter the mature tag

### DIFF
--- a/app/src/main/java/exh/util/LewdMangaChecker.kt
+++ b/app/src/main/java/exh/util/LewdMangaChecker.kt
@@ -31,6 +31,7 @@ private fun isHentaiTag(tag: String): Boolean {
         tag.contains("nsfw", true) ||
         tag.contains("erotica", true) ||
         tag.contains("pornographic", true) ||
+        tag.contains("mature", true) ||
         tag.contains("18+", true)
 }
 
@@ -52,6 +53,8 @@ private fun isHentaiSource(source: String): Boolean {
         source.contains("hbrowse", true) ||
         source.contains("nhentai", true) ||
         source.contains("erofus", true) ||
+        source.contains("luscious", true) ||
+        source.contains("doujins", true) ||
         source.contains("multporn", true) ||
         source.contains("vcp", true) ||
         source.contains("vmp", true) ||


### PR DESCRIPTION
PR for #1035 
- Added the `mature` tag
- Added `doujins` (doujins.com) and `luscious` (luscious.net) as filter keywords
