### PR TITLE
feat(migration): add option to only show entries with new chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -74,6 +74,7 @@ class MigrationBottomSheetDialogState(private val onStartMigration: State<(extra
 
         binding.skipStep.isChecked = preferences.skipPreMigration().get()
         binding.HideNotFoundManga.isChecked = preferences.hideNotFoundMigration().get()
+        binding.OnlyShowUpdates.isChecked = preferences.showOnlyUpdatesMigration().get()
         binding.skipStep.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
                 binding.root.context.toast(
@@ -86,6 +87,7 @@ class MigrationBottomSheetDialogState(private val onStartMigration: State<(extra
         binding.migrateBtn.setOnClickListener {
             preferences.skipPreMigration().set(binding.skipStep.isChecked)
             preferences.hideNotFoundMigration().set(binding.HideNotFoundManga.isChecked)
+            preferences.showOnlyUpdatesMigration().set(binding.OnlyShowUpdates.isChecked)
             onStartMigration.value(
                 if (binding.useSmartSearch.isChecked && binding.extraSearchParamText.text.isNotBlank()) {
                     binding.extraSearchParamText.toString()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
@@ -94,6 +94,7 @@ class MigrationListScreenModel(
     val manualMigrations = MutableStateFlow(0)
 
     val hideNotFound = preferences.hideNotFoundMigration().get()
+    val showOnlyUpdates = preferences.showOnlyUpdatesMigration().get()
 
     val navigateOut = MutableSharedFlow<Unit>()
 
@@ -313,6 +314,12 @@ class MigrationListScreenModel(
                 if (result == null && hideNotFound) {
                     removeManga(manga)
                 }
+                if (result != null && showOnlyUpdates &&
+                    (getChapterInfo(result.id).latestChapter ?: 0.0) <= (manga.chapterInfo.latestChapter ?: 0.0)
+                ) {
+                    removeManga(manga)
+                }
+
                 sourceFinished()
             }
         }

--- a/app/src/main/res/layout/migration_bottom_sheet.xml
+++ b/app/src/main/res/layout/migration_bottom_sheet.xml
@@ -207,11 +207,19 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:layout_marginBottom="82dp"
                 android:paddingHorizontal="16.dp"
                 android:paddingVertical="16dp"
                 android:text="@string/hide_not_found_entries" />
 
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/Only_show_updates"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="82dp"
+                android:paddingHorizontal="16.dp"
+                android:paddingVertical="16dp"
+                android:text="@string/only_show_updated_entries" />
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/domain/src/main/java/tachiyomi/domain/UnsortedPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/UnsortedPreferences.kt
@@ -23,6 +23,8 @@ class UnsortedPreferences(
 
     fun hideNotFoundMigration() = preferenceStore.getBoolean("hide_not_found_migration", false)
 
+    fun showOnlyUpdatesMigration() = preferenceStore.getBoolean("show_only_updates_migration", false)
+
     fun isHentaiEnabled() = preferenceStore.getBoolean("eh_is_hentai_enabled", true)
 
     fun enableExhentai() = preferenceStore.getBoolean(Preference.privateKey("enable_exhentai"), false)

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -461,6 +461,7 @@
     <string name="use_first_source">Use first source with alternative</string>
     <string name="skip_this_step_next_time">Skip this step next time</string>
     <string name="hide_not_found_entries">Hide not found entries</string>
+    <string name="only_show_updated_entries">Only show entries with new chapters</string>
     <string name="search_parameter">Search parameter (e.g. language:english)</string>
     <string name="latest_">Latest: %1$s</string>
     <string name="migrating_to">migrating to</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

This PR adds an option to the migration feature that will only show entries if newer chapters in other sources are available (by comparing the latest chapter number). This makes it easier to find more up-to-date sources. 

### Images

| Image 1 |
| ------- | 
| ![Screenshot_20240727_185836_TachiyomiSY](https://github.com/user-attachments/assets/b1f09d01-74e8-4e87-8530-7d4c05c7df0e) |

