### PR TITLE
Move "Choose what to sync" out of "Sync now"

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -394,10 +394,22 @@ object SettingsDataScreen : SearchableSettings {
         syncServiceType: SyncManager.SyncService,
         syncPreferences: SyncPreferences,
     ): List<Preference> {
-        return when (syncServiceType) {
+        val navigator = LocalNavigator.currentOrThrow
+        val preferences = when (syncServiceType) {
             SyncManager.SyncService.NONE -> emptyList()
             SyncManager.SyncService.SYNCYOMI -> getSelfHostPreferences(syncPreferences)
             SyncManager.SyncService.GOOGLE_DRIVE -> getGoogleDrivePreferences()
+        }
+
+        return if (syncServiceType != SyncManager.SyncService.NONE) {
+            preferences + Preference.PreferenceItem.TextPreference(
+                title = stringResource(SYMR.strings.pref_choose_what_to_sync),
+                onClick = {
+                    navigator.push(SyncSettingsSelector())
+                },
+            )
+        } else {
+            preferences
         }
     }
 
@@ -515,7 +527,7 @@ object SettingsDataScreen : SearchableSettings {
 
     @Composable
     private fun getSyncNowPref(): Preference.PreferenceGroup {
-        val navigator = LocalNavigator.currentOrThrow
+        val context = LocalContext.current
         return Preference.PreferenceGroup(
             title = stringResource(SYMR.strings.pref_sync_now_group_title),
             preferenceItems = persistentListOf(
@@ -524,7 +536,11 @@ object SettingsDataScreen : SearchableSettings {
                     title = stringResource(SYMR.strings.pref_sync_now),
                     subtitle = stringResource(SYMR.strings.pref_sync_now_subtitle),
                     onClick = {
-                        navigator.push(SyncSettingsSelector())
+                        if (!SyncDataJob.isRunning(context)) {
+                            SyncDataJob.startNow(context)
+                        } else {
+                            context.toast(SYMR.strings.sync_in_progress)
+                        }
                     },
                 ),
             ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -16,7 +15,6 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.data.backup.create.BackupOptions
 import eu.kanade.tachiyomi.data.sync.SyncDataJob
-import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.update
 import tachiyomi.i18n.MR
@@ -32,7 +30,6 @@ import uy.kohesive.injekt.api.get
 class SyncSettingsSelector : Screen() {
     @Composable
     override fun Content() {
-        val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
         val model = rememberScreenModel { SyncSettingsSelectorModel() }
         val state by model.state.collectAsState()
@@ -48,15 +45,10 @@ class SyncSettingsSelector : Screen() {
         ) { contentPadding ->
             LazyColumnWithAction(
                 contentPadding = contentPadding,
-                actionLabel = stringResource(SYMR.strings.label_sync),
-                actionEnabled = state.options.canCreate(),
+                actionLabel = stringResource(MR.strings.action_save),
+                actionEnabled = true,
                 onClickAction = {
-                    if (!SyncDataJob.isRunning(context)) {
-                        model.syncNow(context)
-                        navigator.pop()
-                    } else {
-                        context.toast(SYMR.strings.sync_in_progress)
-                    }
+                    navigator.pop()
                 },
             ) {
                 item {


### PR DESCRIPTION
Previously you needed to click `Sync Now` to change what you would like to be synced which was unintuitive.  This PR moves `Chose what to sync` to it's own setting.
### Images
| Previous | Changed |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/f43fa5f2-218e-4777-8c28-0765367d4c9f) | ![image](https://github.com/user-attachments/assets/ea6c066f-27a5-46e7-a8f2-684ee0b892e1) |
| Sync now: ![image](https://github.com/user-attachments/assets/26e9b39e-02c2-4c36-ad27-43255cb0c2f7) | Choose what to sync: ![image](https://github.com/user-attachments/assets/9d27385f-d597-44bc-83e0-ad3cd6456661) |


