### PR TITLE
Get manga info from tracker

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -6,6 +6,7 @@ import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.domain.track.model.toDomainTrack
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.Flow
@@ -118,6 +119,12 @@ abstract class BaseTracker(
     override suspend fun setRemoteFinishDate(track: Track, epochMillis: Long) {
         track.finished_reading_date = epochMillis
         updateRemote(track)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return TrackMangaMetadata(
+            0, "test", "test", "test", "test", "test",
+        )
     }
 
     private suspend fun updateRemote(track: Track): Unit = withIOContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -121,11 +121,7 @@ abstract class BaseTracker(
         updateRemote(track)
     }
 
-    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
-        return TrackMangaMetadata(
-            0, "test", "test", "test", "test", "test",
-        )
-    }
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? = null
 
     private suspend fun updateRemote(track: Track): Unit = withIOContext {
         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -121,7 +121,9 @@ abstract class BaseTracker(
         updateRemote(track)
     }
 
-    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? = null
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        throw NotImplementedError("Not implemented.")
+    }
 
     private suspend fun updateRemote(track: Track): Unit = withIOContext {
         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -84,5 +84,5 @@ interface Tracker {
 
     suspend fun setRemoteFinishDate(track: Track, epochMillis: Long)
 
-    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata?
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -5,6 +5,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.Flow
@@ -82,4 +83,6 @@ interface Tracker {
     suspend fun setRemoteStartDate(track: Track, epochMillis: Long)
 
     suspend fun setRemoteFinishDate(track: Track, epochMillis: Long)
+
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -230,6 +231,10 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
         super.logout()
         trackPreferences.trackToken(this).delete()
         interceptor.setAuth(null)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return api.getMangaMetadata(track)
     }
 
     fun saveOAuth(alOAuth: ALOAuth?) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -233,7 +233,7 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
         interceptor.setAuth(null)
     }
 
-    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
         return api.getMangaMetadata(track)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -5,9 +5,11 @@ import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALAddMangaResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALCurrentUserResult
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListMangaQueryResult
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
@@ -283,6 +285,71 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     .let {
                         val viewer = it.data.viewer
                         Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
+                    }
+            }
+        }
+    }
+
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return withIOContext {
+            val query = """
+            |query (${'$'}mangaId: Int!) {
+                |Media (id: ${'$'}mangaId) {
+                    |id
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |description
+                    |staff {
+                        |edges {
+                            |role
+                            |node {
+                                |name {
+                                    |userPreferred
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            |
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("mangaId", track.remoteId)
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALMangaMetadata>()
+                    .let {
+                        val media = it.data.media
+                        TrackMangaMetadata(
+                            remoteId = media.id,
+                            title = media.title.userPreferred,
+                            thumbnailUrl = media.coverImage.large,
+                            description = media.description,
+                            authors = media.staff.edges
+                                .filter { it.role == "Story" || it.role == "Story & Art" }
+                                .map { it.node.name.userPreferred }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                            artists = media.staff.edges
+                                .filter { it.role == "Art" || it.role == "Story & Art" }
+                                .map { it.node.name.userPreferred }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                        )
                     }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.network.jsonMime
 import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.util.lang.htmlDecode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -338,7 +339,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                             remoteId = media.id,
                             title = media.title.userPreferred,
                             thumbnailUrl = media.coverImage.large,
-                            description = media.description,
+                            description = media.description?.htmlDecode()?.ifEmpty { null },
                             authors = media.staff.edges
                                 .filter { it.role == "Story" || it.role == "Story & Art" }
                                 .map { it.node.name.userPreferred }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALMangaMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALMangaMetadata.kt
@@ -1,0 +1,40 @@
+package eu.kanade.tachiyomi.data.track.anilist.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALMangaMetadata(
+    val data: ALMangaMetadataData,
+)
+
+@Serializable
+data class ALMangaMetadataData(
+    @SerialName("Media")
+    val media: ALMangaMetadataMedia,
+)
+
+@Serializable
+data class ALMangaMetadataMedia(
+    val id: Long,
+    val title: ALItemTitle,
+    val coverImage: ItemCover,
+    val description: String?,
+    val staff: ALStaff,
+)
+
+@Serializable
+data class ALStaff(
+    val edges: List<ALStaffEdge>,
+)
+
+@Serializable
+data class ALStaffEdge(
+    val role: String,
+    val node: ALStaffNode,
+)
+
+@Serializable
+data class ALStaffNode(
+    val name: ALItemTitle,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMOAuth
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -73,6 +74,10 @@ class Bangumi(id: Long) : BaseTracker(id, "Bangumi") {
 
     override suspend fun search(query: String): List<TrackSearch> {
         return api.search(query)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return api.getMangaMetadata(track)
     }
 
     override suspend fun refresh(track: Track): Track {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -7,6 +7,9 @@ import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMCollectionResponse
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMOAuth
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSearchItem
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSearchResult
+import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSubject
+import eu.kanade.tachiyomi.data.track.bangumi.dto.Infobox
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
@@ -21,6 +24,7 @@ import tachiyomi.core.common.util.lang.withIOContext
 import uy.kohesive.injekt.injectLazy
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import tachiyomi.domain.track.model.Track as DomainTrack
 
 class BangumiApi(
     private val trackId: Long,
@@ -121,6 +125,34 @@ class BangumiApi(
                         track.last_chapter_read = it.epStatus!!.toDouble()
                         track.score = it.rating!!
                         track
+                    }
+            }
+        }
+    }
+
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return withIOContext {
+            with(json) {
+                authClient.newCall(GET("${API_URL}/v0/subjects/${track.remoteId}"))
+                    .awaitSuccess()
+                    .parseAs<BGMSubject>()
+                    .let {
+                        TrackMangaMetadata(
+                            remoteId = it.id,
+                            title = it.nameCn,
+                            thumbnailUrl = it.images?.common,
+                            description = it.summary,
+                            authors = it.infobox
+                                .filter { it.key == "作者" }
+                                .filterIsInstance<Infobox.SingleValue>()
+                                .map { it.value }
+                                .joinToString(", "),
+                            artists = it.infobox
+                                .filter { it.key == "插图" }
+                                .filterIsInstance<Infobox.SingleValue>()
+                                .map { it.value }
+                                .joinToString(", "),
+                        )
                     }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSubject.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSubject.kt
@@ -1,0 +1,62 @@
+package eu.kanade.tachiyomi.data.track.bangumi.dto
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+@Serializable
+data class BGMSubject(
+    val images: BGMSearchItemCovers?,
+    val summary: String,
+    val name: String,
+    @SerialName("name_cn")
+    val nameCn: String,
+    val infobox: List<Infobox>,
+    val id: Long,
+)
+
+// infobox deserializer and related classes courtesy of
+// https://github.com/Snd-R/komf/blob/4c260a3dcd326a5e1d74ac9662eec8124ab7e461/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/model/BangumiSubject.kt#L53-L89
+object InfoBoxSerializer : JsonContentPolymorphicSerializer<Infobox>(Infobox::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Infobox> {
+        if (element !is JsonObject) throw SerializationException("Expected JsonObject go ${element::class}")
+        val value = element["value"]
+
+        return when (value) {
+            is JsonArray -> Infobox.MultipleValues.serializer()
+            is JsonPrimitive -> Infobox.SingleValue.serializer()
+            else -> throw SerializationException("Unexpected element type ${element::class}")
+        }
+    }
+}
+
+@Serializable(with = InfoBoxSerializer::class)
+sealed interface Infobox {
+    val key: String
+
+    @Serializable
+    class SingleValue(
+        override val key: String,
+        val value: String,
+    ) : Infobox
+
+    @Serializable
+    class MultipleValues(
+        override val key: String,
+        val value: List<InfoboxNestedValue>,
+    ) : Infobox
+}
+
+@Serializable
+data class InfoboxNestedValue(
+    @SerialName("k")
+    val key: String? = null,
+    @SerialName("v")
+    val value: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuOAuth
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -137,6 +138,10 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
     override fun logout() {
         super.logout()
         interceptor.newAuth(null)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return api.getMangaMetadata(track)
     }
 
     private fun getUserId(): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
@@ -6,8 +6,10 @@ import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuAddMangaResult
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuAlgoliaSearchResult
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuCurrentUserResult
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuListSearchResult
+import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuMangaMetadata
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuOAuth
 import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuSearchResult
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.DELETE
 import eu.kanade.tachiyomi.network.GET
@@ -15,6 +17,7 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.jsonMime
 import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.util.lang.htmlDecode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -240,11 +243,80 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
         }
     }
 
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return withIOContext {
+            val query = """
+            |query(${'$'}libraryId: ID!, ${'$'}staffCount: Int) {
+                |findLibraryEntryById(id: ${'$'}libraryId) {
+                    |media {
+                        |id
+                        |titles {
+                            |preferred
+                        |}
+                        |posterImage {
+                            |original {
+                                |url
+                            |}
+                        |}
+                        |description
+                        |staff(first: ${'$'}staffCount) {
+                            |nodes {
+                                |role
+                                |person {
+                                    |name
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("libraryId", track.remoteId)
+                    put("staffCount", 25) // 25 based on nothing
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        GRAPHQL_URL,
+                        headers = headersOf("Accept-Language", "en"),
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<KitsuMangaMetadata>()
+                    .let {
+                        val manga = it.data.findLibraryEntryById.media
+                        TrackMangaMetadata(
+                            remoteId = manga.id.toLong(),
+                            title = manga.titles.preferred,
+                            thumbnailUrl = manga.posterImage.original.url,
+                            description = manga.description.en?.htmlDecode()?.ifEmpty { null },
+                            authors = manga.staff.nodes
+                                .filter { it.role == "Story" || it.role == "Story & Art" }
+                                .map { it.person.name }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                            artists = manga.staff.nodes
+                                .filter { it.role == "Art" || it.role == "Story & Art" }
+                                .map { it.person.name }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                        )
+                    }
+            }
+        }
+    }
+
     companion object {
         private const val CLIENT_ID = "dd031b32d2f56c990b1425efe6c42ad847e7fe3ab46bf1299f05ecd856bdb7dd"
         private const val CLIENT_SECRET = "54d7307928f63414defd96399fc31ba847961ceaecef3a5fd93144e960c0e151"
 
         private const val BASE_URL = "https://kitsu.app/api/edge/"
+        private const val GRAPHQL_URL = "https://kitsu.app/api/graphql"
         private const val LOGIN_URL = "https://kitsu.app/api/oauth/token"
         private const val BASE_MANGA_URL = "https://kitsu.app/manga/"
         private const val ALGOLIA_KEY_URL = "https://kitsu.app/api/edge/algolia-keys/media/"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuMangaMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuMangaMetadata.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.data.track.kitsu.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KitsuMangaMetadata(
+    val data: KitsuMangaMetadataData,
+)
+
+@Serializable
+data class KitsuMangaMetadataData(
+    val findLibraryEntryById: KitsuMangaMetadataById,
+)
+
+@Serializable
+data class KitsuMangaMetadataById(
+    val media: KitsuMangaMetadataMedia,
+)
+
+@Serializable
+data class KitsuMangaMetadataMedia(
+    val id: String,
+    val titles: KitsuMangaTitle,
+    val posterImage: KitsuMangaCover,
+    val description: KitsuMangaDescription,
+    val staff: KitsuMangaStaff,
+)
+
+@Serializable
+data class KitsuMangaTitle(
+    val preferred: String,
+)
+
+@Serializable
+data class KitsuMangaCover(
+    val original: KitsuMangaCoverUrl,
+)
+
+@Serializable
+data class KitsuMangaCoverUrl(
+    val url: String,
+)
+
+@Serializable
+data class KitsuMangaDescription(
+    val en: String?,
+)
+
+@Serializable
+data class KitsuMangaStaff(
+    val nodes: List<KitsuMangaStaffNode>,
+)
+
+@Serializable
+data class KitsuMangaStaffNode(
+    val role: String,
+    val person: KitsuMangaStaffPerson,
+)
+
+@Serializable
+data class KitsuMangaStaffPerson(
+    val name: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
@@ -10,7 +10,9 @@ import eu.kanade.tachiyomi.data.track.mangaupdates.dto.MUListItem
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.MURating
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.copyTo
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.toTrackSearch
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.util.lang.htmlDecode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import tachiyomi.i18n.MR
@@ -115,6 +117,20 @@ class MangaUpdates(id: Long) : BaseTracker(id, "MangaUpdates"), DeletableTracker
         val authenticated = api.authenticate(username, password) ?: throw Throwable("Unable to login")
         saveCredentials(authenticated.uid.toString(), authenticated.sessionToken)
         interceptor.newAuth(authenticated.sessionToken)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        val series = api.getSeries(track)
+        return series?.let {
+            TrackMangaMetadata(
+                it.seriesId,
+                it.title?.htmlDecode(),
+                it.image?.url?.original,
+                it.description?.htmlDecode(),
+                it.authors?.filter { it.type == "Author" }?.joinToString(separator = ", ") { it.name ?: "" },
+                it.authors?.filter { it.type == "Artist" }?.joinToString(separator = ", ") { it.name ?: "" },
+            )
+        } ?: TrackMangaMetadata()
     }
 
     fun restoreSession(): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
@@ -119,7 +119,7 @@ class MangaUpdates(id: Long) : BaseTracker(id, "MangaUpdates"), DeletableTracker
         interceptor.newAuth(authenticated.sessionToken)
     }
 
-    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
         val series = api.getSeries(track)
         return series?.let {
             TrackMangaMetadata(
@@ -130,7 +130,7 @@ class MangaUpdates(id: Long) : BaseTracker(id, "MangaUpdates"), DeletableTracker
                 it.authors?.filter { it.type == "Author" }?.joinToString(separator = ", ") { it.name ?: "" },
                 it.authors?.filter { it.type == "Artist" }?.joinToString(separator = ", ") { it.name ?: "" },
             )
-        } ?: TrackMangaMetadata()
+        }
     }
 
     fun restoreSession(): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
@@ -190,6 +190,14 @@ class MangaUpdatesApi(
         }
     }
 
+    suspend fun getSeries(track: DomainTrack): MURecord {
+        return with(json) {
+            client.newCall(GET("$BASE_URL/v1/series/${track.remoteId}"))
+                .awaitSuccess()
+                .parseAs<MURecord>()
+        }
+    }
+
     companion object {
         private const val BASE_URL = "https://api.mangaupdates.com"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/Author.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/Author.kt
@@ -1,0 +1,9 @@
+package eu.kanade.tachiyomi.data.track.mangaupdates.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Author(
+    val name: String,
+    val type: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/Author.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/Author.kt
@@ -1,9 +1,0 @@
-package eu.kanade.tachiyomi.data.track.mangaupdates.dto
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class Author(
-    val name: String,
-    val type: String,
-)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
@@ -21,6 +21,7 @@ data class MURecord(
     val ratingVotes: Int? = null,
     @SerialName("latest_chapter")
     val latestChapter: Int? = null,
+    val authors: List<MUAuthor>? = null,
 )
 
 fun MURecord.toTrackSearch(id: Long): TrackSearch {
@@ -36,3 +37,9 @@ fun MURecord.toTrackSearch(id: Long): TrackSearch {
         start_date = this@toTrackSearch.year.toString()
     }
 }
+
+@Serializable
+data class MUAuthor(
+    val type: String? = null,
+    val name: String? = null,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
@@ -2,9 +2,11 @@ package eu.kanade.tachiyomi.data.track.mdlist
 
 import android.graphics.Color
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.domain.track.model.toDbTrack
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
@@ -166,6 +168,21 @@ class MdList(id: Long) : BaseTracker(id, "MDList") {
     override fun logout() {
         super.logout()
         trackPreferences.trackToken(this).delete()
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return withIOContext {
+            val mdex = mdex ?: throw MangaDexNotFoundException()
+            val manga = mdex.getMangaMetadata(track.toDbTrack())
+            TrackMangaMetadata(
+                remoteId = 0,
+                title = manga?.title,
+                thumbnailUrl = manga?.thumbnail_url, // Doesn't load the actual cover because of Refer header
+                description = manga?.description,
+                authors = manga?.author,
+                artists = manga?.artist,
+            )
+        }
     }
 
     override val isLoggedIn: Boolean

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
@@ -1,10 +1,10 @@
 package eu.kanade.tachiyomi.data.track.model
 
 data class TrackMangaMetadata(
-    val remoteId: Long,
-    val title: String,
-    val thumbnailUrl: String?,
-    val description: String?,
-    val authors: String?,
-    val artists: String?,
+    val remoteId: Long? = null,
+    val title: String? = null,
+    val thumbnailUrl: String? = null,
+    val description: String? = null,
+    val authors: String? = null,
+    val artists: String? = null,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
@@ -1,0 +1,10 @@
+package eu.kanade.tachiyomi.data.track.model
+
+data class TrackMangaMetadata(
+    val remoteId: Long,
+    val title: String,
+    val thumbnailUrl: String?,
+    val description: String?,
+    val authors: String?,
+    val artists: String?,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
 import kotlinx.collections.immutable.ImmutableList
@@ -154,6 +155,10 @@ class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
         super.logout()
         trackPreferences.trackToken(this).delete()
         interceptor.setAuth(null)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return api.getMangaMetadata(track)
     }
 
     fun getIfAuthExpired(): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -3,10 +3,12 @@ package eu.kanade.tachiyomi.data.track.myanimelist
 import android.net.Uri
 import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALListItem
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALListItemStatus
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALManga
+import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALMangaMetadata
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALSearchResult
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUser
@@ -189,6 +191,41 @@ class MyAnimeListApi(
                 matches + findListItems(query, offset + LIST_PAGINATION_AMOUNT)
             } else {
                 matches
+            }
+        }
+    }
+
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return withIOContext {
+            val url = "$BASE_API_URL/manga".toUri().buildUpon()
+                .appendPath(track.remoteId.toString())
+                .appendQueryParameter(
+                    "fields",
+                    "id,title,synopsis,main_picture,authors{first_name,last_name}",
+                )
+                .build()
+            with(json) {
+                authClient.newCall(GET(url.toString()))
+                    .awaitSuccess()
+                    .parseAs<MALMangaMetadata>()
+                    .let {
+                        TrackMangaMetadata(
+                            remoteId = it.id,
+                            title = it.title,
+                            thumbnailUrl = it.covers.large.ifEmpty { null } ?: it.covers.medium,
+                            description = it.synopsis,
+                            authors = it.authors
+                                .filter { it.role == "Story" || it.role == "Story & Art" }
+                                .map { "{it.node.firstName} {it.node.lastName}".trim() }
+                                .joinToString(separator = ", ")
+                                .ifEmpty { null },
+                            artists = it.authors
+                                .filter { it.role == "Art" || it.role == "Story & Art" }
+                                .map { "{it.node.firstName} {it.node.lastName}".trim() }
+                                .joinToString(separator = ", ")
+                                .ifEmpty { null },
+                        )
+                    }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -216,12 +216,12 @@ class MyAnimeListApi(
                             description = it.synopsis,
                             authors = it.authors
                                 .filter { it.role == "Story" || it.role == "Story & Art" }
-                                .map { "{it.node.firstName} {it.node.lastName}".trim() }
+                                .map { "${it.node.firstName} ${it.node.lastName}".trim() }
                                 .joinToString(separator = ", ")
                                 .ifEmpty { null },
                             artists = it.authors
                                 .filter { it.role == "Art" || it.role == "Story & Art" }
-                                .map { "{it.node.firstName} {it.node.lastName}".trim() }
+                                .map { "${it.node.firstName} ${it.node.lastName}".trim() }
                                 .joinToString(separator = ", ")
                                 .ifEmpty { null },
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
@@ -23,4 +23,29 @@ data class MALManga(
 @Serializable
 data class MALMangaCovers(
     val large: String = "",
+    val medium: String,
+)
+
+@Serializable
+data class MALMangaMetadata(
+    val id: Long,
+    val title: String,
+    val synopsis: String?,
+    @SerialName("main_picture")
+    val covers: MALMangaCovers,
+    val authors: List<MALAuthor>,
+)
+
+@Serializable
+data class MALAuthor(
+    val node: MALAuthorNode,
+    val role: String,
+)
+
+@Serializable
+data class MALAuthorNode(
+    @SerialName("first_name")
+    val firstName: String,
+    @SerialName("last_name")
+    val lastName: String,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMOAuth
 import kotlinx.collections.immutable.ImmutableList
@@ -96,6 +97,10 @@ class Shikimori(id: Long) : BaseTracker(id, "Shikimori"), DeletableTracker {
             track.total_chapters = remoteTrack.total_chapters
         } ?: throw Exception("Could not find manga")
         return track
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return api.getMangaMetadata(track)
     }
 
     override fun getLogo() = R.drawable.ic_tracker_shikimori

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMMetadata.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.track.shikimori.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SMMetadata(
+    val data: SMMetadataData,
+)
+
+@Serializable
+data class SMMetadataData(
+    val mangas: List<SMMetadataResult>,
+)
+
+@Serializable
+data class SMMetadataResult(
+    val id: String,
+    val name: String,
+    val description: String,
+    val poster: SMMangaPoster,
+    val personRoles: List<SMMangaPersonRoles>,
+)
+
+@Serializable
+data class SMMangaPoster(
+    val originalUrl: String,
+)
+
+@Serializable
+data class SMMangaPersonRoles(
+    val person: SMPerson,
+    val rolesEn: List<String>,
+)
+
+@Serializable
+data class SMPerson(
+    val name: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -313,6 +313,10 @@ class MangaDex(delegate: HttpSource, val context: Context) :
         return similarHandler.getRelated(manga)
     }
 
+    suspend fun getMangaMetadata(track: Track): SManga? {
+        return mangaHandler.getMangaMetadata(track, id, coverQuality(), tryUsingFirstVolumeCover(), altTitlesInDesc())
+    }
+
     companion object {
         private const val dataSaverPref = "dataSaverV5"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -34,6 +34,7 @@ import com.google.android.material.chip.ChipGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import eu.kanade.presentation.track.components.TrackLogoIcon
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.databinding.EditMangaDialogBinding
@@ -287,6 +288,7 @@ private suspend fun getTrackers(manga: Manga, binding: EditMangaDialogBinding, c
     tracks.value = getTracks.await(manga.id).map { track ->
         track to trackerManager.get(track.trackerId)!!
     }
+        .filterNot { (_, tracker) -> tracker is EnhancedTracker }
 
     if (tracks.value.isEmpty()) {
         context.toast(context.stringResource(SYMR.strings.entry_not_tracked))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -80,8 +80,8 @@ fun EditMangaDialog(
         mutableStateOf<EditMangaDialogBinding?>(null)
     }
     val showTrackerSelectionDialogue = remember { mutableStateOf(false) }
-    val getTracks = Injekt.get<GetTracks>()
-    val trackerManager = Injekt.get<TrackerManager>()
+    val getTracks = remember { Injekt.get<GetTracks>() }
+    val trackerManager = remember { Injekt.get<TrackerManager>() }
     val tracks = remember { mutableStateOf(emptyList<Pair<Track, Tracker>>()) }
     AlertDialog(
         onDismissRequest = onDismissRequest,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -171,7 +171,7 @@ private fun TrackerSelectDialog(
             }
         },
         title = {
-            Text("Select a tracker")
+            Text(stringResource(SYMR.strings.select_tracker))
         },
         text = {
             FlowRow(
@@ -289,7 +289,7 @@ private suspend fun getTrackers(manga: Manga, binding: EditMangaDialogBinding, c
     }
 
     if (tracks.value.isEmpty()) {
-        context.toast("Entry not tracked.")
+        context.toast(context.stringResource(SYMR.strings.entry_not_tracked))
         return
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -48,9 +48,8 @@ import exh.util.trimOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
-import logcat.asLog
-import logcat.logcat
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.track.interactor.GetTracks
 import tachiyomi.domain.track.model.Track
@@ -316,7 +315,7 @@ private suspend fun autofillFromTracker(binding: EditMangaDialogBinding, track: 
         setTextIfNotBlank(binding.thumbnailUrl::setText, trackerMangaMetadata?.thumbnailUrl)
         setTextIfNotBlank(binding.mangaDescription::setText, trackerMangaMetadata?.description)
     } catch (e: Throwable) {
-        logcat("[MetadataAutofill] [${tracker.name}] ", LogPriority.ERROR) { e.asLog() }
+        tracker.logcat(LogPriority.ERROR, e)
         binding.root.context.toast(
             binding.root.context.stringResource(
                 MR.strings.track_error,

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -119,4 +119,10 @@ data class DummyTracker(
         track: eu.kanade.tachiyomi.data.database.models.Track,
         epochMillis: Long,
     ) = Unit
+
+    override suspend fun getMangaMetadata(
+        track: tachiyomi.domain.track.model.Track,
+    ): eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata = eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata(
+        0, "test", "test", "test", "test", "test",
+    )
 }

--- a/app/src/main/res/layout/edit_manga_dialog.xml
+++ b/app/src/main/res/layout/edit_manga_dialog.xml
@@ -129,21 +129,20 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="12dp" />
 
+    <Button
+        android:id="@+id/autofill_from_tracker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:text="Autofill from tracker"
+        android:textAllCaps="false" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/autofill_from_tracker"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="8dp"
-            android:text="Autofill from tracker"
-            android:textAllCaps="false" />
-
 
         <Button
             android:id="@+id/reset_tags"

--- a/app/src/main/res/layout/edit_manga_dialog.xml
+++ b/app/src/main/res/layout/edit_manga_dialog.xml
@@ -129,25 +129,42 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="12dp" />
 
-    <Button
-        android:id="@+id/reset_tags"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="8dp"
-        android:text="@string/reset_tags"
-        android:textAllCaps="false" />
+        android:orientation="horizontal">
 
-    <Button
-        android:id="@+id/reset_info"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="8dp"
-        android:text="@string/reset_info"
-        android:textAllCaps="false" />
+        <Button
+            android:id="@+id/autofill_from_tracker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:text="Autofill from tracker"
+            android:textAllCaps="false" />
+
+
+        <Button
+            android:id="@+id/reset_tags"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:text="@string/reset_tags"
+            android:textAllCaps="false" />
+
+        <Button
+            android:id="@+id/reset_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:text="@string/reset_info"
+            android:textAllCaps="false" />
+    </LinearLayout>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/edit_manga_dialog.xml
+++ b/app/src/main/res/layout/edit_manga_dialog.xml
@@ -136,7 +136,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
-        android:text="Autofill from tracker"
+        android:text="@string/fill_from_tracker"
         android:textAllCaps="false" />
 
     <LinearLayout

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -405,6 +405,7 @@
     <string name="multi_tags_comma_separated">Enter tag(s), seperated by commas.</string>
     <string name="select_tracker">Select a tracker</string>
     <string name="entry_not_tracked">Entry is not tracked.</string>
+    <string name="fill_from_tracker">Fill from tracker</string>
 
     <!-- Browse -->
     <!-- Sources Tab -->

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -403,6 +403,8 @@
     <string name="artist_hint">Artist: %1$s</string>
     <string name="thumbnail_url_hint">Thumbnail Url: %1$s</string>
     <string name="multi_tags_comma_separated">Enter tag(s), seperated by commas.</string>
+    <string name="select_tracker">Select a tracker</string>
+    <string name="entry_not_tracked">Entry is not tracked.</string>
 
     <!-- Browse -->
     <!-- Sources Tab -->


### PR DESCRIPTION
Allows setting manga info to the one provided by tracker (currently includes title, author, artist, thumbnail url and description).

Closes #1205 

TODO:
- [x] Implement for all trackers.
- [x] Properly handle multiple trackers.
- [x] Handle rate-limits and other `HttpException`s (hoping a single try catch is enough)
- [ ] ~~Automatically fetch metadata when tracker is added to an entry for the first time (?)~~ Decided against it ([discord](https://discord.com/channels/1195734228319617024/1195836976167932074/1302861304469524523))
- [x] Replace strings with moko strings.