### PR TITLE
Hide sync library option when sync is disabled

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -41,6 +41,7 @@ fun LibraryToolbar(
     onClickSyncNow: () -> Unit,
     // SY -->
     onClickSyncExh: (() -> Unit)?,
+    isSyncEnabled: Boolean,
     // SY <--
     searchQuery: String?,
     onSearchQueryChange: (String?) -> Unit,
@@ -64,6 +65,7 @@ fun LibraryToolbar(
         onClickSyncNow = onClickSyncNow,
         // SY -->
         onClickSyncExh = onClickSyncExh,
+        isSyncEnabled = isSyncEnabled,
         // SY <--
         scrollBehavior = scrollBehavior,
     )
@@ -82,6 +84,7 @@ private fun LibraryRegularToolbar(
     onClickSyncNow: () -> Unit,
     // SY -->
     onClickSyncExh: (() -> Unit)?,
+    isSyncEnabled: Boolean,
     // SY <--
     scrollBehavior: TopAppBarScrollBehavior?,
 ) {
@@ -128,10 +131,6 @@ private fun LibraryRegularToolbar(
                         title = stringResource(MR.strings.action_open_random_manga),
                         onClick = onClickOpenRandomManga,
                     ),
-                    AppBar.OverflowAction(
-                        title = stringResource(SYMR.strings.sync_library),
-                        onClick = onClickSyncNow,
-                    ),
                 ).builder().apply {
                     // SY -->
                     if (onClickSyncExh != null) {
@@ -139,6 +138,14 @@ private fun LibraryRegularToolbar(
                             AppBar.OverflowAction(
                                 title = stringResource(SYMR.strings.sync_favorites),
                                 onClick = onClickSyncExh,
+                            ),
+                        )
+                    }
+                    if (isSyncEnabled) {
+                        add(
+                            AppBar.OverflowAction(
+                                title = stringResource(SYMR.strings.sync_library),
+                                onClick = onClickSyncNow,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -22,6 +22,7 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.chapter.interactor.SetReadStatus
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.presentation.components.SEARCH_DEBOUNCE_MILLIS
 import eu.kanade.presentation.library.components.LibraryToolbarTitle
 import eu.kanade.presentation.manga.DownloadAction
@@ -151,6 +152,7 @@ class LibraryScreenModel(
     private val searchEngine: SearchEngine = Injekt.get(),
     private val setCustomMangaInfo: SetCustomMangaInfo = Injekt.get(),
     private val getMergedChaptersByMangaId: GetMergedChaptersByMangaId = Injekt.get(),
+    private val syncPreferences: SyncPreferences = Injekt.get(),
     // SY <--
 ) : StateScreenModel<LibraryScreenModel.State>(State()) {
 
@@ -276,6 +278,7 @@ class LibraryScreenModel(
                 }
             }
             .launchIn(screenModelScope)
+        mutableState.update { it.copy(isSyncEnabled = syncPreferences.isSyncEnabled()) }
         // SY <--
     }
 
@@ -1362,6 +1365,7 @@ class LibraryScreenModel(
         val dialog: Dialog? = null,
         // SY -->
         val showSyncExh: Boolean = false,
+        val isSyncEnabled: Boolean = false,
         val ogCategories: List<Category> = emptyList(),
         val groupType: Int = LibraryGroup.BY_DEFAULT,
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -280,10 +280,9 @@ class LibraryScreenModel(
             .launchIn(screenModelScope)
         syncPreferences.syncService()
             .changes()
+            .distinctUntilChanged()
             .onEach { syncService ->
-                mutableState.update { state ->
-                    state.copy(isSyncEnabled = syncService != 0)
-                }
+                mutableState.update { it.copy(isSyncEnabled = syncService != 0) }
             }
             .launchIn(screenModelScope)
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -280,8 +280,10 @@ class LibraryScreenModel(
             .launchIn(screenModelScope)
         syncPreferences.syncService()
             .changes()
-            .onEach {
-                mutableState.update { it.copy(isSyncEnabled = it != 0) }
+            .onEach { syncService ->
+                mutableState.update { state ->
+                    state.copy(isSyncEnabled = syncService != 0)
+                }
             }
             .launchIn(screenModelScope)
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -278,7 +278,12 @@ class LibraryScreenModel(
                 }
             }
             .launchIn(screenModelScope)
-        mutableState.update { it.copy(isSyncEnabled = syncPreferences.isSyncEnabled()) }
+        syncPreferences.syncService()
+            .changes()
+            .onEach {
+                mutableState.update { it.copy(isSyncEnabled = it != 0) }
+            }
+            .launchIn(screenModelScope)
         // SY <--
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -172,6 +172,7 @@ object LibraryTab : Tab {
                     },
                     // SY -->
                     onClickSyncExh = screenModel::openFavoritesSyncDialog.takeIf { state.showSyncExh },
+                    isSyncEnabled = state.isSyncEnabled,
                     // SY <--
                     searchQuery = state.searchQuery,
                     onSearchQueryChange = screenModel::search,


### PR DESCRIPTION
Tried to implement this draft pull (https://github.com/jobobby04/TachiyomiSY/pull/1203) as it was inactive for a long time.

- Add isSyncEnabled parameter to LibraryToolbar and LibraryRegularToolbar
- Pass isSyncEnabled from LibraryTab to LibraryToolbar
- Conditionally display sync library action based on isSyncEnabled
- Update LibraryContent to include isSyncEnabled parameter
- Adjust LibraryTab to handle sync-related functionality
- Remove direct dependency on SyncPreferences in LibraryToolbar

### Images
| Sync On | Sync Off |
| ------- | ------- |
| ![Screenshot_20240912-232212](https://github.com/user-attachments/assets/b23ebfab-2e1f-4585-8615-5cb010c4aebb) | ![Screenshot_20240912-232135](https://github.com/user-attachments/assets/d189e747-5c63-4f30-a74a-803e2d599a5a) |
