### PR TITLE
Add support for .webp image extension

### DIFF
--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -130,6 +130,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
         fun typeToExtension(t: String?) =
             when (t) {
+                "w" -> "webp"
                 "p" -> "png"
                 "j" -> "jpg"
                 "g" -> "gif"


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Previews for newer doujins were not displayed because the images are mostly presented in .webp format, I suppose this little change can fix that issue.

Closes #1321
