### PR TITLE
Maintain correct source order even when receiving new chapters from a sync service

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -202,7 +202,7 @@ class MangaRestorer(
                 bookmark = chapter.bookmark || dbChapter.bookmark,
                 read = chapter.read,
                 lastPageRead = chapter.lastPageRead,
-                sourceOrder = chapter.sourceOrder
+                sourceOrder = chapter.sourceOrder,
             )
         } else {
             chapter.copyFrom(dbChapter).let {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -202,6 +202,7 @@ class MangaRestorer(
                 bookmark = chapter.bookmark || dbChapter.bookmark,
                 read = chapter.read,
                 lastPageRead = chapter.lastPageRead,
+                sourceOrder = chapter.sourceOrder
             )
         } else {
             chapter.copyFrom(dbChapter).let {
@@ -252,7 +253,7 @@ class MangaRestorer(
                     bookmark = chapter.bookmark,
                     lastPageRead = chapter.lastPageRead,
                     chapterNumber = null,
-                    sourceOrder = null,
+                    sourceOrder = if (isSync) chapter.sourceOrder else null,
                     dateFetch = null,
                     dateUpload = null,
                     chapterId = chapter.id,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -233,7 +233,12 @@ abstract class SyncService(
                 localChapter != null && remoteChapter != null -> {
                     // Use version number to decide which chapter to keep
                     val chosenChapter = if (localChapter.version >= remoteChapter.version) {
-                        localChapter
+                        // If there mare more chapter on remote, local sourceOrder will need to be updated to maintain correct source order.
+                        if (localChapters.size < remoteChapters.size) {
+                            localChapter.copy(sourceOrder = remoteChapter.sourceOrder)
+                        } else {
+                            localChapter
+                        }
                     } else {
                         remoteChapter
                     }
@@ -500,6 +505,7 @@ abstract class SyncService(
                     logcat(LogPriority.DEBUG, logTag) { "Using remote saved search: ${remoteSearch.name}." }
                     remoteSearch
                 }
+
                 else -> {
                     logcat(LogPriority.DEBUG, logTag) {
                         "No saved search found for composite key: $compositeKey. Skipping."


### PR DESCRIPTION
**Fixes #1339**

#### Problem description and origin

If chapters are pushed to a sync service from Device A and these new chapters are then received by Device B, the source order of these chapters will be wrong because the existing chapters have not gotten their source order adjusted. This source order usually changes when new chapters get added or old ones get removed, however, as-is local chapters will still be in the order of before with the new chapters now colliding with the old chapters (leading to orders like "Chapter 38" -> "Chapter 43" -> "Chapter 37" -> "Chapter 42" -> ...).

#### How this PR fixes the problem

The proposed changes now ensure that this corner case for syncing is caught and the `sourceOrder` of the chapters are now in the correct order. I made it so that existing behavior not sync-related should remain unaffected.

#### Screenshot illustrating the problem

![393552769-3519cc72-ca2d-4d0d-9144-0cc6e6b45288 - Copy](https://github.com/user-attachments/assets/2a3ef821-c9c8-41fd-912e-b2e0db986414)

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
