### PR TITLE
feat: add global search shortcut to SmartSearch

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseTabWrapper.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseTabWrapper.kt
@@ -11,7 +11,7 @@ import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
-fun BrowseTabWrapper(tab: TabContent) {
+fun BrowseTabWrapper(tab: TabContent, onBackPressed: (() -> Unit)? = null) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
         topBar = { scrollBehavior ->
@@ -20,6 +20,7 @@ fun BrowseTabWrapper(tab: TabContent) {
                 actions = {
                     AppBarActions(tab.actions)
                 },
+                navigateUp = onBackPressed,
                 scrollBehavior = scrollBehavior,
             )
         },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesScreen.kt
@@ -1,12 +1,15 @@
 package eu.kanade.tachiyomi.ui.browse.migration.sources
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.BrowseTabWrapper
 import eu.kanade.presentation.util.Screen
 
 class MigrationSourcesScreen : Screen() {
     @Composable
     override fun Content() {
-        BrowseTabWrapper(migrateSourceTab())
+        val navigator = LocalNavigator.currentOrThrow
+        BrowseTabWrapper(migrateSourceTab(), onBackPressed = navigator::pop)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreen.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.ui.browse.source
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.BrowseTabWrapper
 import eu.kanade.presentation.util.Screen
 import java.io.Serializable
@@ -8,7 +10,8 @@ import java.io.Serializable
 class SourcesScreen(private val smartSearchConfig: SmartSearchConfig?) : Screen() {
     @Composable
     override fun Content() {
-        BrowseTabWrapper(sourcesTab(smartSearchConfig))
+        val navigator = LocalNavigator.currentOrThrow
+        BrowseTabWrapper(sourcesTab(smartSearchConfig), onBackPressed = navigator::pop)
     }
 
     data class SmartSearchConfig(val origTitle: String, val origMangaId: Long? = null) : Serializable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -49,15 +49,18 @@ fun Screen.sourcesTab(
                 icon = Icons.Outlined.TravelExplore,
                 onClick = { navigator.push(GlobalSearchScreen(smartSearchConfig?.origTitle ?: "")) },
             ),
-        ).apply {
-            if (smartSearchConfig == null) {
-                add(
-                    AppBar.Action(
-                        title = stringResource(MR.strings.action_filter),
-                        icon = Icons.Outlined.FilterList,
-                        onClick = { navigator.push(SourcesFilterScreen()) },
-                    ),
-                )
+        ).let {
+            when (smartSearchConfig) {
+                null -> {
+                    it.add(
+                        AppBar.Action(
+                            title = stringResource(MR.strings.action_filter),
+                            icon = Icons.Outlined.FilterList,
+                            onClick = { navigator.push(SourcesFilterScreen()) },
+                        ),
+                    )
+                }
+                else -> it
             }
         },
         // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -43,21 +43,22 @@ fun Screen.sourcesTab(
             true -> MR.strings.label_sources
             false -> SYMR.strings.find_in_another_source
         },
-        actions = if (smartSearchConfig == null) {
-            persistentListOf(
-                AppBar.Action(
-                    title = stringResource(MR.strings.action_global_search),
-                    icon = Icons.Outlined.TravelExplore,
-                    onClick = { navigator.push(GlobalSearchScreen()) },
-                ),
-                AppBar.Action(
-                    title = stringResource(MR.strings.action_filter),
-                    icon = Icons.Outlined.FilterList,
-                    onClick = { navigator.push(SourcesFilterScreen()) },
-                ),
-            )
-        } else {
-            persistentListOf()
+        actions = persistentListOf(
+            AppBar.Action(
+                title = stringResource(MR.strings.action_global_search),
+                icon = Icons.Outlined.TravelExplore,
+                onClick = { navigator.push(GlobalSearchScreen(smartSearchConfig?.origTitle ?: "")) },
+            ),
+        ).apply {
+            if (smartSearchConfig == null) {
+                add(
+                    AppBar.Action(
+                        title = stringResource(MR.strings.action_filter),
+                        icon = Icons.Outlined.FilterList,
+                        onClick = { navigator.push(SourcesFilterScreen()) },
+                    ),
+                )
+            }
         },
         // SY <--
         content = { contentPadding, snackbarHostState ->


### PR DESCRIPTION
Shows the global search action button in the top-right corner when using the SmartSearch source selection.
That helps users to select a source if they are unsure what to pick, for example when tapping on tracker recommendations.

Also adds a back button to the screen (might fix #865, not sure).

Closes #210
Closes #446

### Images
| Image 1 | 
| ------- | 
| <img src="https://github.com/user-attachments/assets/c779363c-a54e-4292-bee8-6b5641331039" width="300"> |
