### PR TITLE
Fix CDN subdomain for delegated source covers

### DIFF
--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -46,7 +46,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
         val cover = if (mediaId != null) {
             typeToExtension(coverImageType)?.let {
-                "https://t.nhentai.net/galleries/$mediaId/cover.$it"
+                "https://t3.nhentai.net/galleries/$mediaId/cover.$it"
             }
         } else {
             null


### PR DESCRIPTION
Simply replaced the numberless CDN subdomain discontinued after the introduction of `.webp` covers for the same one used for page thumbnails.

Fixes #1374