### PR TITLE
Use COMPLETE category when sync finishes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
@@ -27,7 +27,7 @@ class SyncNotifier(private val context: Context) {
     }
 
     private val completeNotificationBuilder = context.notificationBuilder(
-        Notifications.CHANNEL_BACKUP_RESTORE_PROGRESS,
+        Notifications.CHANNEL_BACKUP_RESTORE_COMPLETE,
     ) {
         setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
         setSmallIcon(R.drawable.ic_tachi)


### PR DESCRIPTION
Categorize sync complete/error notifications as `CHANNEL_BACKUP_RESTORE_COMPLETE` instead of `CHANNEL_BACKUP_RESTORE_PROGRESS`. This matches the behavior of the BackupNotifier.

This doesn't completely fix  #1325, but it's a low-hanging fruit to improve the experience somewhat.