### PR TITLE
Populate Author field and clear Description on a couple sources

### DIFF
--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/EHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/EHentaiSearchMetadata.kt
@@ -66,6 +66,11 @@ class EHentaiSearchMetadata : RaisedSearchMetadata() {
             .ifEmpty { null }
             ?.joinToString { it.name }
 
+        // Set group (if we can find one)
+        val group = tags.ofNamespace(EH_GROUP_NAMESPACE)
+            .ifEmpty { null }
+            ?.joinToString { it.name }
+
         // Copy tags -> genres
         val genres = tagsToGenreString()
 
@@ -80,13 +85,12 @@ class EHentaiSearchMetadata : RaisedSearchMetadata() {
             }
         }
 
-        val description = "meta"
-
         return manga.copy(
             url = key ?: manga.url,
             title = title ?: manga.title,
-            artist = artist ?: manga.artist,
-            description = description,
+            artist = group ?: manga.artist,
+            author = artist ?: manga.artist,
+            description = null,
             genre = genres,
             status = status,
             thumbnail_url = cover ?: manga.thumbnail_url,
@@ -145,6 +149,7 @@ class EHentaiSearchMetadata : RaisedSearchMetadata() {
 
         const val EH_GENRE_NAMESPACE = "genre"
         private const val EH_ARTIST_NAMESPACE = "artist"
+        private const val EH_GROUP_NAMESPACE = "group"
         const val EH_LANGUAGE_NAMESPACE = "language"
         const val EH_META_NAMESPACE = "meta"
         const val EH_UPLOADER_NAMESPACE = "uploader"

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -63,6 +63,11 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
             if (tags.isNotEmpty()) tags.joinToString(transform = { it.name }) else null
         }
 
+        // Set group (if we can find one)
+        val group = tags.ofNamespace(NHENTAI_GROUP_NAMESPACE).let { tags ->
+            if (tags.isNotEmpty()) tags.joinToString(transform = { it.name }) else null
+        }
+
         // Copy tags -> genres
         val genres = tagsToGenreString()
 
@@ -77,16 +82,15 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
             }
         }
 
-        val description = "meta"
-
         return manga.copy(
             url = key ?: manga.url,
             thumbnail_url = cover ?: manga.thumbnail_url,
             title = title,
-            artist = artist ?: manga.artist,
+            artist = group ?: manga.artist,
+            author = artist ?: manga.artist,
             genre = genres,
             status = status,
-            description = description,
+            description = null,
         )
     }
 
@@ -126,6 +130,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
         const val BASE_URL = "https://nhentai.net"
 
         private const val NHENTAI_ARTIST_NAMESPACE = "artist"
+        private const val NHENTAI_GROUP_NAMESPACE = "group"
         const val NHENTAI_CATEGORIES_NAMESPACE = "category"
 
         fun typeToExtension(t: String?) =


### PR DESCRIPTION
Fix the "Unknown author" field on the built-in and a delegated source:
 - Set the Artist (🖌) field to joined Group tags (a.k.a. doujin circle) if available, joined Artist tags otherwise
 - Set the Author (👤) field to joined Artist tags
 - If Author and Artist have the same value, Artist (🖌) gets hidden

Null the description instead of writing `meta`

### Images
| Before | After |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/ca5dce91-15ae-4628-bd6f-997beba9e7ab) | ![image](https://github.com/user-attachments/assets/1ddd05c6-d0ad-4aba-96b6-eeaa72f202a8) |
| ![image](https://github.com/user-attachments/assets/be01d19b-6da5-4990-956b-bc3936f50def) | ![image](https://github.com/user-attachments/assets/cd632946-f113-4560-8d03-00b58b54a8cf) |