### PR TITLE
Remove the unused mark duplicate as read preference.

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -227,13 +227,6 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = readerPreferences.skipDupe(),
                     title = stringResource(MR.strings.pref_skip_dupe_chapters),
                 ),
-                // SY -->
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.markReadDupe(),
-                    title = stringResource(SYMR.strings.pref_mark_read_dupe_chapters),
-                    subtitle = stringResource(SYMR.strings.pref_mark_read_dupe_chapters_summary),
-                ),
-                // SY <--
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.alwaysShowChapterTransition(),
                     title = stringResource(MR.strings.pref_always_show_chapter_transition),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -184,8 +184,6 @@ class ReaderPreferences(
     fun centerMarginType() = preferenceStore.getInt("center_margin_type", PagerConfig.CenterMarginType.NONE)
 
     fun archiveReaderMode() = preferenceStore.getInt("archive_reader_mode", ArchiveReaderMode.LOAD_FROM_FILE)
-
-    fun markReadDupe() = preferenceStore.getBoolean("mark_read_dupe", false)
     // SY <--
 
     enum class FlashColor {

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -46,4 +46,5 @@ val migrations: List<Migration>
         MoveEncryptionSettingsToAppStateMigration(),
         TrustExtensionRepositoryMigration(),
         CategoryPreferencesCleanupMigration(),
+        RemoveDuplicateReaderPreferenceMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/RemoveDuplicateReaderPreferenceMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/RemoveDuplicateReaderPreferenceMigration.kt
@@ -10,8 +10,15 @@ class RemoveDuplicateReaderPreferenceMigration : Migration {
     override val version: Float = 74f
 
     override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
-        migrationContext.get<SharedPreferences>()?.edit {
-            remove("mark_read_dupe")
+        val prefs = migrationContext.get<SharedPreferences>() ?: return@withIOContext false
+
+        if (prefs.getBoolean("mark_read_dupe", false)) {
+            val readPrefSet = prefs.getStringSet("mark_duplicate_read_chapter_read", emptySet())?.toMutableSet()
+            readPrefSet?.add("existing")
+            prefs.edit {
+                putStringSet("mark_duplicate_read_chapter_read", readPrefSet)
+                remove("mark_read_dupe")
+            }
         }
 
         return@withIOContext true

--- a/app/src/main/java/mihon/core/migration/migrations/RemoveDuplicateReaderPreferenceMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/RemoveDuplicateReaderPreferenceMigration.kt
@@ -1,0 +1,19 @@
+package mihon.core.migration.migrations
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.util.lang.withIOContext
+
+class RemoveDuplicateReaderPreferenceMigration : Migration {
+    override val version: Float = 74f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
+        migrationContext.get<SharedPreferences>()?.edit {
+            remove("mark_read_dupe")
+        }
+
+        return@withIOContext true
+    }
+}


### PR DESCRIPTION
Removed  `markReadDupe` preference from `ReaderPreferences` as `markDuplicateReadChapterAsRead` from `LibraryPreferences` is the one that's actually used.