### PR TITLE
Change log file extension to .txt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -328,7 +328,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
                             return super.generateFileName(
                                 logLevel,
                                 timestamp,
-                            ) + "-${BuildConfig.BUILD_TYPE}.log"
+                            ) + "-${BuildConfig.BUILD_TYPE}.txt"
                         }
                     }
                     flattener { timeMillis, level, tag, message ->


### PR DESCRIPTION
Fixes issues with logging to file on certain devices (mine, for example).

This returns `<date>-<build_type>.log`.
https://github.com/jobobby04/TachiyomiSY/blob/ab5ff00c393991e2f239a347f7894dc42fc25342/app/src/main/java/exh/log/EnhancedFilePrinter.kt#L62

But, this creates `<date>-<build_type>.txt` causing issues. 
https://github.com/jobobby04/TachiyomiSY/blob/ab5ff00c393991e2f239a347f7894dc42fc25342/app/src/main/java/exh/log/EnhancedFilePrinter.kt#L76

This PR changes the extension to .txt to (hopefully) prevent any issues.