### PR TITLE
Fix screen not turning off while in library tab

### DIFF
--- a/app/src/main/java/exh/recs/batch/RecommendationSearchProgressDialog.kt
+++ b/app/src/main/java/exh/recs/batch/RecommendationSearchProgressDialog.kt
@@ -40,8 +40,10 @@ fun RecommendationSearchProgressDialog(
     val context = LocalContext.current
     val currentView = LocalView.current
 
-    DisposableEffect(Unit) {
-        currentView.keepScreenOn = true
+    DisposableEffect(status) {
+        if (status != SearchStatus.Idle) {
+            currentView.keepScreenOn = true
+        }
         onDispose {
             currentView.keepScreenOn = false
         }


### PR DESCRIPTION
Closes #1431 

Added a check to keep screen on only while the recommendation search status is not idle.

Not sure why the progress dialog needs the screen to stay on. Should the entirety of this be removed?