### PR TITLE
Add a screen to view tracked entries that are not in library

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -155,7 +155,7 @@ private fun LibraryRegularToolbar(
                             ),
                         )
                     }
-                    if (hasLoggedInTrackers) {
+                    if (hasLoggedInTrackers) { // TODO: Add a check for implemented trackers
                         add(
                             AppBar.OverflowAction(
                                 title = "Tracker Manga",

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -155,7 +155,7 @@ private fun LibraryRegularToolbar(
                             ),
                         )
                     }
-                    if (hasLoggedInTrackers) { // TODO: Add a check for implemented trackers
+                    if (hasLoggedInTrackers) {
                         add(
                             AppBar.OverflowAction(
                                 title = "Tracker Manga",

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -43,6 +43,7 @@ fun LibraryToolbar(
     onClickSyncExh: (() -> Unit)?,
     isSyncEnabled: Boolean,
     onClickTrackerManga: () -> Unit,
+    hasLoggedInTrackers: Boolean,
     // SY <--
     searchQuery: String?,
     onSearchQueryChange: (String?) -> Unit,
@@ -68,6 +69,7 @@ fun LibraryToolbar(
         onClickSyncExh = onClickSyncExh,
         isSyncEnabled = isSyncEnabled,
         onClickTrackerManga = onClickTrackerManga,
+        hasLoggedInTrackers = hasLoggedInTrackers,
         // SY <--
         scrollBehavior = scrollBehavior,
     )
@@ -88,6 +90,7 @@ private fun LibraryRegularToolbar(
     onClickSyncExh: (() -> Unit)?,
     isSyncEnabled: Boolean,
     onClickTrackerManga: () -> Unit,
+    hasLoggedInTrackers: Boolean,
     // SY <--
     scrollBehavior: TopAppBarScrollBehavior?,
 ) {
@@ -134,10 +137,6 @@ private fun LibraryRegularToolbar(
                         title = stringResource(MR.strings.action_open_random_manga),
                         onClick = onClickOpenRandomManga,
                     ),
-                    AppBar.OverflowAction(
-                        title = "Tracker Manga",
-                        onClick = onClickTrackerManga,
-                    ),
                 ).builder().apply {
                     // SY -->
                     if (onClickSyncExh != null) {
@@ -153,6 +152,14 @@ private fun LibraryRegularToolbar(
                             AppBar.OverflowAction(
                                 title = stringResource(SYMR.strings.sync_library),
                                 onClick = onClickSyncNow,
+                            ),
+                        )
+                    }
+                    if (hasLoggedInTrackers) {
+                        add(
+                            AppBar.OverflowAction(
+                                title = "Tracker Manga",
+                                onClick = onClickTrackerManga,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -42,6 +42,7 @@ fun LibraryToolbar(
     // SY -->
     onClickSyncExh: (() -> Unit)?,
     isSyncEnabled: Boolean,
+    onClickTrackerManga: () -> Unit,
     // SY <--
     searchQuery: String?,
     onSearchQueryChange: (String?) -> Unit,
@@ -66,6 +67,7 @@ fun LibraryToolbar(
         // SY -->
         onClickSyncExh = onClickSyncExh,
         isSyncEnabled = isSyncEnabled,
+        onClickTrackerManga = onClickTrackerManga,
         // SY <--
         scrollBehavior = scrollBehavior,
     )
@@ -85,6 +87,7 @@ private fun LibraryRegularToolbar(
     // SY -->
     onClickSyncExh: (() -> Unit)?,
     isSyncEnabled: Boolean,
+    onClickTrackerManga: () -> Unit,
     // SY <--
     scrollBehavior: TopAppBarScrollBehavior?,
 ) {
@@ -130,6 +133,10 @@ private fun LibraryRegularToolbar(
                     AppBar.OverflowAction(
                         title = stringResource(MR.strings.action_open_random_manga),
                         onClick = onClickOpenRandomManga,
+                    ),
+                    AppBar.OverflowAction(
+                        title = "Tracker Manga",
+                        onClick = onClickTrackerManga,
                     ),
                 ).builder().apply {
                     // SY -->

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
@@ -3,16 +3,25 @@ package eu.kanade.presentation.library.tracker
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -24,7 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -32,11 +41,16 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.library.tracker.components.TrackStatusTabs
 import eu.kanade.presentation.library.tracker.components.mangaListItem
+import eu.kanade.presentation.track.components.TrackLogoIcon
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import kotlinx.coroutines.launch
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
 import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -55,7 +69,7 @@ class TrackerMangaListScreen : Screen() {
 
         Scaffold(
             topBar = { scrollBehaviour ->
-                TrackerMangaListAppBar(scrollBehaviour, navigator::pop)
+                TrackerMangaListAppBar(screenModel.getTrackerName(), scrollBehaviour, navigator::pop, screenModel::toggleTrackerSelectDialog)
             },
         ) { contentPadding ->
             when {
@@ -66,6 +80,10 @@ class TrackerMangaListScreen : Screen() {
                         initialPage = state.currentTabIndex.coerceIn(0, state.statusList.lastIndex),
                         pageCount = { state.statusList.size },
                     )
+
+                    LaunchedEffect(state.trackerId) {
+                        pagerState.animateScrollToPage(0)
+                    }
 
                     Column(modifier = Modifier.padding(contentPadding)) {
                         TrackStatusTabs(
@@ -80,37 +98,36 @@ class TrackerMangaListScreen : Screen() {
                         HorizontalPager(
                             state = pagerState,
                             modifier = Modifier.fillMaxSize(),
-                        ) {
-                            val currentTabIndex = pagerState.currentPage
-                            val currentTabState = state.tabs[currentTabIndex] ?: TabMangaList()
+                        ) { page ->
+                            val currentTabState = state.tabs[page] ?: TabMangaList()
 
                             val currentScrollState = remember {
                                 LazyListState(
-                                    firstVisibleItemIndex = scrollStates[pagerState.currentPage]?.first ?: 0,
-                                    firstVisibleItemScrollOffset = scrollStates[pagerState.currentPage]?.second ?: 0,
+                                    firstVisibleItemIndex = scrollStates[page]?.first ?: 0,
+                                    firstVisibleItemScrollOffset = scrollStates[page]?.second ?: 0,
                                 )
                             }
 
-                            LaunchedEffect(currentTabIndex, currentScrollState) {
+                            LaunchedEffect(page, currentScrollState, state.trackerId) {
                                 snapshotFlow {
                                     val layoutInfo = currentScrollState.layoutInfo
                                     val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                                    lastVisible >= layoutInfo.totalItemsCount - 15
+                                    lastVisible >= layoutInfo.totalItemsCount - 20
                                 }.collect { shouldLoadMore ->
                                     if (shouldLoadMore) {
-                                        screenModel.loadNextPage(currentTabIndex)
+                                        screenModel.loadNextPage(page)
                                     }
                                 }
                             }
 
-                            LaunchedEffect(pagerState.currentPage) {
+                            LaunchedEffect(page) {
                                 snapshotFlow {
                                     currentScrollState.firstVisibleItemIndex to currentScrollState.firstVisibleItemScrollOffset
                                 }
                                     .collect { (index, offset) ->
-                                        scrollStates[pagerState.currentPage] = index to offset
+                                        scrollStates[page] = index to offset
                                     }
-                                screenModel.changeTab(pagerState.currentPage)
+                                screenModel.changeTab(page)
                             }
 
                             val isFirstLoad = currentTabState.isLoading && currentTabState.items.isEmpty()
@@ -158,24 +175,94 @@ class TrackerMangaListScreen : Screen() {
                 }
             }
         }
+
+        if (state.trackerSelectDialog) {
+            TrackerSelectDialog(
+                screenModel.trackers,
+                onDismissRequest = screenModel::toggleTrackerSelectDialog,
+                onTrackerSelect = screenModel::changeTracker,
+                currentTrackerId = state.trackerId!!,
+            )
+        }
+
     }
 }
 
 @Composable
 fun TrackerMangaListAppBar(
+    title: String,
     scrollBehavior: TopAppBarScrollBehavior,
     navigateUp: () -> Unit,
+    onShowTrackerDialogClick: () -> Unit,
 ) {
     AppBar(
         navigateUp = navigateUp,
         titleContent = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "Tracker Manga",
+                    text = title,
                     maxLines = 1,
                 )
             }
         },
+        actions = {
+            IconButton(onClick = onShowTrackerDialogClick) {
+                Icon(
+                    imageVector = Icons.Default.Sync,
+                    contentDescription = "Select tracker",
+                )
+            }
+        },
         scrollBehavior = scrollBehavior,
+    )
+}
+
+@Composable
+fun TrackerSelectDialog(
+    trackers: List<Tracker>,
+    onDismissRequest: () -> Unit,
+    onTrackerSelect: (Long) -> Unit,
+    currentTrackerId: Long,
+) {
+    AlertDialog(
+        modifier = Modifier.fillMaxWidth(),
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(MR.strings.action_cancel))
+            }
+        },
+        title = {
+            Text(stringResource(SYMR.strings.select_tracker))
+        },
+        text = {
+            FlowRow(
+                modifier = Modifier.padding(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                trackers.forEach { tracker ->
+                    Box {
+                        TrackLogoIcon(
+                            tracker,
+                            onClick = {
+                                if (tracker.id != currentTrackerId) {
+                                    onTrackerSelect(tracker.id)
+                                }
+                            },
+                        )
+                        if (tracker.id == currentTrackerId) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .size(16.dp),
+                                tint = Color.Green,
+                            )
+                        }
+                    }
+                }
+            }
+        },
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import dev.icerock.moko.resources.StringResource
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.library.tracker.components.TrackStatusTabs
 import eu.kanade.presentation.library.tracker.components.mangaListItem
@@ -123,11 +122,13 @@ class TrackerMangaListScreen : Screen() {
                                         try {
                                             screenModel.loadNextPage(page)
                                         } catch (e: Exception) {
-                                            context.toast(context.stringResource(
-                                                MR.strings.track_error,
-                                                screenModel.getTrackerName(),
-                                                e.message ?: "",
-                                            ))
+                                            context.toast(
+                                                context.stringResource(
+                                                    MR.strings.track_error,
+                                                    screenModel.getTrackerName(),
+                                                    e.message ?: "",
+                                                ),
+                                            )
                                         }
                                     }
                                 }
@@ -143,11 +144,13 @@ class TrackerMangaListScreen : Screen() {
                                 try {
                                     screenModel.changeTab(page)
                                 } catch (e: Exception) {
-                                    context.toast(context.stringResource(
-                                        MR.strings.track_error,
-                                        screenModel.getTrackerName(),
-                                        e.message ?: "",
-                                    ))
+                                    context.toast(
+                                        context.stringResource(
+                                            MR.strings.track_error,
+                                            screenModel.getTrackerName(),
+                                            e.message ?: "",
+                                        ),
+                                    )
                                 }
                             }
 
@@ -205,7 +208,6 @@ class TrackerMangaListScreen : Screen() {
                 currentTrackerId = state.trackerId!!,
             )
         }
-
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreen.kt
@@ -1,0 +1,181 @@
+package eu.kanade.presentation.library.tracker
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.library.tracker.components.TrackStatusTabs
+import eu.kanade.presentation.library.tracker.components.mangaListItem
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
+import kotlinx.coroutines.launch
+import tachiyomi.presentation.core.components.FastScrollLazyColumn
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+
+class TrackerMangaListScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        val screenModel = rememberScreenModel { TrackerMangaListScreenModel() }
+        val state by screenModel.state.collectAsState()
+        val scope = rememberCoroutineScope()
+        val scrollStates = remember {
+            mutableStateMapOf<Int, Pair<Int, Int>>()
+        }
+
+        Scaffold(
+            topBar = { scrollBehaviour ->
+                TrackerMangaListAppBar(scrollBehaviour, navigator::pop)
+            },
+        ) { contentPadding ->
+            when {
+                state.statusList.isEmpty() -> LoadingScreen(modifier = Modifier.padding(contentPadding))
+
+                else -> {
+                    val pagerState = rememberPagerState(
+                        initialPage = state.currentTabIndex.coerceIn(0, state.statusList.lastIndex),
+                        pageCount = { state.statusList.size },
+                    )
+
+                    Column(modifier = Modifier.padding(contentPadding)) {
+                        TrackStatusTabs(
+                            statusList = state.statusList,
+                            getStatusRes = state.getStatusRes,
+                            pagerState = pagerState,
+                        ) { index ->
+                            scope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            val currentTabIndex = pagerState.currentPage
+                            val currentTabState = state.tabs[currentTabIndex] ?: TabMangaList()
+
+                            val currentScrollState = remember {
+                                LazyListState(
+                                    firstVisibleItemIndex = scrollStates[pagerState.currentPage]?.first ?: 0,
+                                    firstVisibleItemScrollOffset = scrollStates[pagerState.currentPage]?.second ?: 0,
+                                )
+                            }
+
+                            LaunchedEffect(currentTabIndex, currentScrollState) {
+                                snapshotFlow {
+                                    val layoutInfo = currentScrollState.layoutInfo
+                                    val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                                    lastVisible >= layoutInfo.totalItemsCount - 15
+                                }.collect { shouldLoadMore ->
+                                    if (shouldLoadMore) {
+                                        screenModel.loadNextPage(currentTabIndex)
+                                    }
+                                }
+                            }
+
+                            LaunchedEffect(pagerState.currentPage) {
+                                snapshotFlow {
+                                    currentScrollState.firstVisibleItemIndex to currentScrollState.firstVisibleItemScrollOffset
+                                }
+                                    .collect { (index, offset) ->
+                                        scrollStates[pagerState.currentPage] = index to offset
+                                    }
+                                screenModel.changeTab(pagerState.currentPage)
+                            }
+
+                            val isFirstLoad = currentTabState.isLoading && currentTabState.items.isEmpty()
+                            if (isFirstLoad) {
+                                LoadingScreen(modifier = Modifier.fillMaxWidth())
+                                return@HorizontalPager
+                            }
+
+                            if (currentTabState.items.isEmpty()) {
+                                EmptyScreen(
+                                    message = "All entries are in library.",
+                                    modifier = Modifier.fillMaxSize(),
+                                )
+                                return@HorizontalPager
+                            }
+
+                            FastScrollLazyColumn(
+                                state = currentScrollState,
+                                modifier = Modifier.fillMaxHeight(),
+                                verticalArrangement = Arrangement.Top,
+                            ) {
+                                mangaListItem(
+                                    items = currentTabState.items,
+                                    onClick = { item ->
+                                        navigator.push(
+                                            GlobalSearchScreen(searchQuery = item.title ?: ""),
+                                        )
+                                    },
+                                )
+                                if (currentTabState.isLoading) {
+                                    item {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularProgressIndicator()
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TrackerMangaListAppBar(
+    scrollBehavior: TopAppBarScrollBehavior,
+    navigateUp: () -> Unit,
+) {
+    AppBar(
+        navigateUp = navigateUp,
+        titleContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Tracker Manga",
+                    maxLines = 1,
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/TrackerMangaListScreenModel.kt
@@ -1,0 +1,96 @@
+package eu.kanade.presentation.library.tracker
+
+import android.content.Context
+import androidx.compose.runtime.Immutable
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import dev.icerock.moko.resources.StringResource
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
+import kotlinx.coroutines.flow.update
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.domain.manga.interactor.GetLibraryManga
+import tachiyomi.domain.track.interactor.GetTracks
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class TrackerMangaListScreenModel(
+    private val getLibraryManga: GetLibraryManga = Injekt.get(),
+    private val getTracks: GetTracks = Injekt.get(),
+    private val trackerManager: TrackerManager = Injekt.get(),
+) : StateScreenModel<TrackerMangaListState>(TrackerMangaListState()) {
+
+    private var remoteIds: Set<Long> = emptySet()
+
+    init {
+        screenModelScope.launchIO {
+            val tracker = trackerManager.loggedInTrackers().firstOrNull() ?: return@launchIO
+            val mangaIds = getLibraryManga.await().map { it.id }.toSet()
+            remoteIds = getTracks.await().filter { it.mangaId in mangaIds && it.trackerId == tracker.id }.map { it.remoteId }.toSet()
+            mutableState.update {
+                TrackerMangaListState(
+                    trackerId = tracker.id,
+                    statusList = tracker.getStatusList(),
+                    getStatusRes = tracker::getStatus,
+                )
+            }
+        }
+    }
+
+    fun changeTab(index: Int) {
+        mutableState.update {
+            it.copy(currentTabIndex = index)
+        }
+        if (mutableState.value.tabs[index]?.items?.isEmpty() != false) {
+            loadNextPage(index)
+        }
+    }
+
+    fun loadNextPage(tabIndex: Int) {
+        val currentTab = mutableState.value.tabs[tabIndex] ?: TabMangaList()
+        if (currentTab.isLoading || currentTab.endReached) return
+
+        screenModelScope.launchIO {
+            val trackerId = mutableState.value.trackerId ?: return@launchIO
+            val tracker = trackerManager.get(trackerId) ?: return@launchIO
+
+            val statusId = mutableState.value.statusList.getOrNull(tabIndex) ?: return@launchIO
+            val currentPage = currentTab.page
+
+            mutableState.update {
+                it.copy(
+                    tabs = it.tabs + (tabIndex to currentTab.copy(isLoading = true)),
+                )
+            }
+
+            val newItems = tracker.getPaginatedMangaList(currentPage, statusId).filterNot { it.remoteId in remoteIds }
+
+            mutableState.update {
+                val updatedTab = currentTab.copy(
+                    items = currentTab.items + newItems,
+                    page = currentPage + 1,
+                    isLoading = false,
+                    endReached = newItems.isEmpty(),
+                )
+                it.copy(tabs = it.tabs + (tabIndex to updatedTab))
+            }
+        }
+    }
+}
+
+@Immutable
+data class TrackerMangaListState(
+    val statusList: List<Long> = emptyList(),
+    val getStatusRes: (Long) -> StringResource? = { null },
+    val trackerId: Long? = null,
+    val currentTabIndex: Int = 0,
+    val tabs: Map<Int, TabMangaList> = emptyMap(),
+)
+
+@Immutable
+data class TabMangaList(
+    val items: List<TrackMangaMetadata> = emptyList(),
+    val page: Int = 1,
+    val endReached: Boolean = false,
+    val isLoading: Boolean = false,
+)

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/components/MangaListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/components/MangaListItem.kt
@@ -1,0 +1,70 @@
+package eu.kanade.presentation.library.tracker.components
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
+
+fun LazyListScope.mangaListItem(
+    items: List<TrackMangaMetadata>,
+    onClick: (TrackMangaMetadata) -> Unit,
+) {
+    items(
+        items = items,
+        key = { it.remoteId!! },
+    ) { item ->
+        Box(modifier = Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null, placementSpec = tween(300))) {
+            MangaListItem(
+                modifier = Modifier,
+                manga = item,
+                onClick = { onClick(item) },
+            )
+        }
+    }
+}
+
+@Composable
+fun MangaListItem(
+    modifier: Modifier,
+    manga: TrackMangaMetadata,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .height(56.dp)
+            .combinedClickable(
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MangaCover.Square(
+            modifier = Modifier
+                .fillMaxHeight(),
+            data = manga.thumbnailUrl,
+        )
+        Text(
+            text = manga.title!!,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .weight(1f),
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/library/tracker/components/TrackStatusTabs.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/tracker/components/TrackStatusTabs.kt
@@ -1,0 +1,53 @@
+package eu.kanade.presentation.library.tracker.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import dev.icerock.moko.resources.StringResource
+import tachiyomi.presentation.core.components.material.TabText
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun TrackStatusTabs(
+    statusList: List<Long>,
+    getStatusRes: (Long) -> StringResource?,
+    pagerState: PagerState,
+    onTabItemClick: (Int) -> Unit,
+) {
+    val currentPageIndex = pagerState.currentPage.coerceAtMost(statusList.lastIndex)
+
+    Column(
+        modifier = Modifier
+            .zIndex(1f),
+    ) {
+        PrimaryScrollableTabRow(
+            selectedTabIndex = currentPageIndex,
+            edgePadding = 0.dp,
+            // TODO: use default when width is fixed upstream
+            // https://issuetracker.google.com/issues/242879624
+            divider = {},
+        ) {
+            statusList.forEachIndexed { index, status ->
+                Tab(
+                    selected = currentPageIndex == index,
+                    onClick = { onTabItemClick(index) },
+                    text = {
+                        TabText(
+                            text = stringResource(getStatusRes(status)!!),
+                        )
+                    },
+                    unselectedContentColor = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+
+        HorizontalDivider()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -137,6 +137,10 @@ abstract class BaseTracker(
     override suspend fun searchById(id: String): TrackSearch? {
         throw NotImplementedError("Not implemented.")
     }
+
+    override suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata> {
+        throw NotImplementedError("Not implemented.")
+    }
     // SY <--
 
     private suspend fun updateRemote(track: Track): Unit = withIOContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -92,5 +92,7 @@ interface Tracker {
     suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata?
 
     suspend fun searchById(id: String): TrackSearch?
+
+    suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata>
     // SY <--
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -234,13 +234,17 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
         interceptor.setAuth(null)
     }
 
+    // SY -->
     override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
         return api.getMangaMetadata(track)
     }
 
-    // SY -->
     override suspend fun searchById(id: String): TrackSearch {
         return api.searchById(id)
+    }
+
+    override suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata> {
+        return api.getPaginatedMangaList(page, statusId, getUsername().toInt())
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListMangaQueryResult
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserMangaListQueryResult
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.POST
@@ -432,6 +433,54 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     .data.media
                     .toALManga()
                     .toTrack()
+            }
+        }
+    }
+
+    suspend fun getPaginatedMangaList(page: Int, statusId: Long, userId: Int): List<TrackMangaMetadata> {
+        return withIOContext {
+            val query = """
+                |query (${'$'}id: Int!, ${'$'}page: Int!, ${'$'}status: MediaListStatus!) {
+                    |Page(perPage: 50, page: ${'$'}page) {
+                        |mediaList(userId: ${'$'}id, type: MANGA, status: ${'$'}status) {
+                            |media {
+                                |id
+                                |title {
+                                    |userPreferred
+                                |}
+                                |coverImage {
+                                    |large
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("page", page)
+                    put("id", userId)
+                    put("status", statusId.toApiStatus())
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALUserMangaListQueryResult>()
+                    .data.page.mediaList
+                    .map { entry ->
+                        TrackMangaMetadata(
+                            remoteId = entry.media.id,
+                            title = entry.media.title.userPreferred,
+                            thumbnailUrl = entry.media.coverImage.large,
+                        )
+                    }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistUtils.kt
@@ -5,6 +5,16 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import uy.kohesive.injekt.injectLazy
 import tachiyomi.domain.track.model.Track as DomainTrack
 
+fun Long.toApiStatus() = when (this) {
+    Anilist.READING -> "CURRENT"
+    Anilist.COMPLETED -> "COMPLETED"
+    Anilist.ON_HOLD -> "PAUSED"
+    Anilist.DROPPED -> "DROPPED"
+    Anilist.PLAN_TO_READ -> "PLANNING"
+    Anilist.REREADING -> "REPEATING"
+    else -> throw NotImplementedError("Unknown status: $this")
+}
+
 fun Track.toApiStatus() = when (status) {
     Anilist.READING -> "CURRENT"
     Anilist.COMPLETED -> "COMPLETED"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserMangaList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserMangaList.kt
@@ -1,0 +1,32 @@
+package eu.kanade.tachiyomi.data.track.anilist.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALUserMangaListQueryResult(
+    val data: ALUserMangaListPage,
+)
+
+@Serializable
+data class ALUserMangaListPage(
+    @SerialName("Page")
+    val page: ALUserMangaListMediaList,
+)
+
+@Serializable
+data class ALUserMangaListMediaList(
+    val mediaList: List<ALUserMediaListEntry>,
+)
+
+@Serializable
+data class ALUserMediaListEntry(
+    val media: ALUserMediaListEntryMedia,
+)
+
+@Serializable
+data class ALUserMediaListEntryMedia(
+    val id: Long,
+    val title: ALItemTitle,
+    val coverImage: ItemCover,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackMangaMetadata.kt
@@ -7,4 +7,5 @@ data class TrackMangaMetadata(
     val description: String? = null,
     val authors: String? = null,
     val artists: String? = null,
+    val libraryStatus: Int? = null,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -156,13 +156,17 @@ class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
         interceptor.setAuth(null)
     }
 
+    // SY -->
     override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
         return api.getMangaMetadata(track)
     }
 
-    // SY -->
     override suspend fun searchById(id: String): TrackSearch {
         return api.getMangaDetails(id.toInt())
+    }
+
+    override suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata> {
+        return api.getPaginatedMangaList(page, statusId)
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -236,10 +236,10 @@ class MyAnimeListApi(
                 .appendQueryParameter("status", "${statusId.toMyAnimeListStatus()}")
                 .appendQueryParameter("fields", "list_status")
                 .appendQueryParameter("limit", 50.toString())
-                .appendQueryParameter("offset", ((page-1) * 50).toString())
+                .appendQueryParameter("offset", ((page - 1) * 50).toString())
 
             val request = Request.Builder().url(urlBuilder.build().toString()).get().build()
-            with (json) {
+            with(json) {
                 val data = authClient.newCall(request)
                     .awaitSuccess()
                     .parseAs<MALUserSearchResult>()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -230,6 +230,35 @@ class MyAnimeListApi(
         }
     }
 
+    suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata> {
+        return withIOContext {
+            val urlBuilder = "$BASE_API_URL/users/@me/mangalist".toUri().buildUpon()
+                .appendQueryParameter("status", "${statusId.toMyAnimeListStatus()}")
+                .appendQueryParameter("fields", "list_status")
+                .appendQueryParameter("limit", 50.toString())
+                .appendQueryParameter("offset", ((page-1) * 50).toString())
+
+            val request = Request.Builder().url(urlBuilder.build().toString()).get().build()
+            with (json) {
+                val data = authClient.newCall(request)
+                    .awaitSuccess()
+                    .parseAs<MALUserSearchResult>()
+                    .data
+                data.mapNotNull {
+                    if (statusId == MyAnimeList.REREADING && !it.listStatus!!.isRereading) {
+                        null
+                    } else {
+                        TrackMangaMetadata(
+                            remoteId = it.node.id.toLong(),
+                            title = it.node.title,
+                            thumbnailUrl = it.node.covers?.large,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     private suspend fun getListPage(offset: Int): MALUserSearchResult {
         return withIOContext {
             val urlBuilder = "$BASE_API_URL/users/@me/mangalist".toUri().buildUpon()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.myanimelist
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Long.toMyAnimeListStatus() = when(this) {
+fun Long.toMyAnimeListStatus() = when (this) {
     MyAnimeList.READING -> "reading"
     MyAnimeList.COMPLETED -> "completed"
     MyAnimeList.ON_HOLD -> "on_hold"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
@@ -2,6 +2,16 @@ package eu.kanade.tachiyomi.data.track.myanimelist
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
+fun Long.toMyAnimeListStatus() = when(this) {
+    MyAnimeList.READING -> "reading"
+    MyAnimeList.COMPLETED -> "completed"
+    MyAnimeList.ON_HOLD -> "on_hold"
+    MyAnimeList.DROPPED -> "dropped"
+    MyAnimeList.PLAN_TO_READ -> "plan_to_read"
+    MyAnimeList.REREADING -> "reading"
+    else -> null
+}
+
 fun Track.toMyAnimeListStatus() = when (status) {
     MyAnimeList.READING -> "reading"
     MyAnimeList.COMPLETED -> "completed"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALUserListSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALUserListSearch.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.track.myanimelist.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -11,6 +12,8 @@ data class MALUserSearchResult(
 @Serializable
 data class MALUserSearchItem(
     val node: MALUserSearchItemNode,
+    @SerialName("list_status")
+    val listStatus: MALListItemStatus?,
 )
 
 @Serializable
@@ -22,4 +25,6 @@ data class MALUserSearchPaging(
 data class MALUserSearchItemNode(
     val id: Int,
     val title: String,
+    @SerialName("main_picture")
+    val covers: MALMangaCovers?,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.library
 import android.app.Application
 import android.content.Context
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.util.fastAll
@@ -30,8 +29,11 @@ import eu.kanade.presentation.manga.DownloadAction
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.anilist.Anilist
+import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeList
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -292,8 +294,13 @@ class LibraryScreenModel(
 
         screenModelScope.launchIO {
             trackerManager.loggedInTrackersFlow().collectLatest { trackerList ->
-                mutableState.update {
-                    it.copy(hasLoggedInTrackers = trackerList.isNotEmpty())
+                mutableState.update { state ->
+                    state.copy(hasLoggedInTrackers = trackerList.filterNot { it is EnhancedTracker }.any { tracker ->
+                        tracker::class in listOf(
+                            Anilist::class, MyAnimeList::class,
+                        )
+                    }
+                    )
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -295,11 +295,12 @@ class LibraryScreenModel(
         screenModelScope.launchIO {
             trackerManager.loggedInTrackersFlow().collectLatest { trackerList ->
                 mutableState.update { state ->
-                    state.copy(hasLoggedInTrackers = trackerList.filterNot { it is EnhancedTracker }.any { tracker ->
-                        tracker::class in listOf(
-                            Anilist::class, MyAnimeList::class,
-                        )
-                    }
+                    state.copy(
+                        hasLoggedInTrackers = trackerList.filterNot { it is EnhancedTracker }.any { tracker ->
+                            tracker::class in listOf(
+                                Anilist::class, MyAnimeList::class,
+                            )
+                        },
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.ui.library
 import android.app.Application
 import android.content.Context
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.util.fastAll
@@ -288,6 +289,14 @@ class LibraryScreenModel(
                 mutableState.update { it.copy(isSyncEnabled = syncService != 0) }
             }
             .launchIn(screenModelScope)
+
+        screenModelScope.launchIO {
+            trackerManager.loggedInTrackersFlow().collectLatest { trackerList ->
+                mutableState.update {
+                    it.copy(hasLoggedInTrackers = trackerList.isNotEmpty())
+                }
+            }
+        }
         // SY <--
     }
 
@@ -1399,6 +1408,7 @@ class LibraryScreenModel(
         val isSyncEnabled: Boolean = false,
         val ogCategories: List<Category> = emptyList(),
         val groupType: Int = LibraryGroup.BY_DEFAULT,
+        val hasLoggedInTrackers: Boolean = false,
         // SY <--
     ) {
         private val libraryCount by lazy {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -179,6 +179,7 @@ data object LibraryTab : Tab {
                     onClickSyncExh = screenModel::openFavoritesSyncDialog.takeIf { state.showSyncExh },
                     isSyncEnabled = state.isSyncEnabled,
                     onClickTrackerManga = { navigator.push(TrackerMangaListScreen()) },
+                    hasLoggedInTrackers = state.hasLoggedInTrackers,
                     // SY <--
                     searchQuery = state.searchQuery,
                     onSearchQueryChange = screenModel::search,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -37,6 +37,7 @@ import eu.kanade.presentation.library.components.LibraryToolbar
 import eu.kanade.presentation.library.components.SyncFavoritesConfirmDialog
 import eu.kanade.presentation.library.components.SyncFavoritesProgressDialog
 import eu.kanade.presentation.library.components.SyncFavoritesWarningDialog
+import eu.kanade.presentation.library.tracker.TrackerMangaListScreen
 import eu.kanade.presentation.manga.components.LibraryBottomActionMenu
 import eu.kanade.presentation.more.onboarding.GETTING_STARTED_URL
 import eu.kanade.presentation.util.Tab
@@ -177,6 +178,7 @@ data object LibraryTab : Tab {
                     // SY -->
                     onClickSyncExh = screenModel::openFavoritesSyncDialog.takeIf { state.showSyncExh },
                     isSyncEnabled = state.isSyncEnabled,
+                    onClickTrackerManga = { navigator.push(TrackerMangaListScreen()) },
                     // SY <--
                     searchQuery = state.searchQuery,
                     onSearchQueryChange = screenModel::search,

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.track.Tracker
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -127,10 +128,12 @@ data class DummyTracker(
     ) = Unit
 
     override suspend fun getMangaMetadata(
-        track: tachiyomi.domain.track.model.Track,
-    ): eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata = eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata(
+        track: Track,
+    ): TrackMangaMetadata = TrackMangaMetadata(
         0, "test", "test", "test", "test", "test",
     )
 
     override suspend fun searchById(id: String) = null
+
+    override suspend fun getPaginatedMangaList(page: Int, statusId: Long): List<TrackMangaMetadata> = emptyList()
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/784ed28c-ea09-4106-8381-e6ea385e62bb)
![image](https://github.com/user-attachments/assets/9e6aefa9-7984-4699-b0da-d4d56876dbeb)

Only AniList and MyAnimeList are implemented so far. I will do Mangaupdates later, but, I will not be doing the rest of the trackers as they don't seem *that* popular (and I, personally, don't use them).