### PR TITLE
Configure Coil-cache to no longer leak memory,

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -19,6 +19,9 @@ import androidx.work.Configuration
 import androidx.work.WorkManager
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
@@ -245,6 +248,19 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
                 add(PagePreviewKeyer())
                 // SY <--
             }
+
+            memoryCache(
+                MemoryCache.Builder()
+                    .maxSizePercent(context,0.25)
+                    .build(),
+            )
+
+            diskCache(
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache"))
+                    .maxSizePercent(0.02)
+                    .build(),
+            )
 
             crossfade((300 * this@App.animatorDurationScale).toInt())
             allowRgb565(DeviceUtil.isLowRamDevice(this@App))


### PR DESCRIPTION
Right now, the app will keep all images it has ever fetched using Coil in memory and eventually crash once allocations become impossable. This configures the memory caching in Coil in the way presented by the [official documentation](https://coil-kt.github.io/coil/image_loaders/), limiting the maximum amount of memory consumed and configuring a disk cache, reducing pressure on sources (I can remove that part if unwanted).

Related to [this PR](https://github.com/mihonapp/mihon/pull/2266)

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
