### PR TITLE
QoL: Adjust zoom level when auto zooming on wide images

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -43,6 +43,7 @@ import okio.BufferedSource
 import tachiyomi.core.common.util.system.ImageUtil
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.math.min
 
 /**
  * A wrapper view for showing page image.
@@ -138,7 +139,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
                 }
 
                 val targetScale = height.toFloat() / sHeight.toFloat()
-                (animateScaleAndCenter(targetScale, point) ?: return@postDelayed)
+                (animateScaleAndCenter(min(targetScale, minScale * 2), point) ?: return@postDelayed)
                     .withDuration(500)
                     .withEasing(EASE_IN_OUT_QUAD)
                     .withInterruptible(true)


### PR DESCRIPTION
This is adapted from j2k (the land of QoL) - works well with smart fit and fit screen (the latter is what I usually use and this has previously prevented me from using the combination of dual-page reader + pan navigation on zoomed in images + zoom into wide images automagically - until now). Can provide a video recording upon request to show the differences in UX

Relevant j2k code snippet (which also uses insets which might help even more but I didn't need it): https://github.com/Jays2Kings/tachiyomiJ2K/blob/e04c1efa8283b61c5550ce2e289c5e6408c9c0cb/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt#L361

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
