### PR TITLE
Fix deletion of duplicate downloaded chapters when automatically marked as read

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -764,14 +764,17 @@ class ReaderViewModel @JvmOverloads constructor(
                     chapter.chapterNumber.toFloat() == readerChapter.chapter.chapter_number
                 ) {
                     ChapterUpdate(id = chapter.id, read = true)
-                        // SY -->
-                        .also { deleteChapterIfNeeded(ReaderChapter(chapter)) }
-                    // SY <--
                 } else {
                     null
                 }
             }
         updateChapter.awaitAll(duplicateUnreadChapters)
+        // SY -->
+        duplicateUnreadChapters.forEach { chapterUpdate ->
+            val chapter = unfilteredChapterList.first { it.id == chapterUpdate.id }
+            deleteChapterIfNeeded(ReaderChapter(chapter))
+        }
+        // SY <--
     }
 
     fun restartReadTimer() {


### PR DESCRIPTION
`deleteChapterIfNeeded` was called before the duplicate chapters were marked as read. Since `deleteChapterIfNeeded` calls `enqueueDeleteReadChapters` which doesn't delete unread chapters, the downloaded duplicate chapters weren't being deleted as expected.