### PR TITLE
Refactor BrowseSource components to use key for state management in item lists removing crash while scrolling thorugh EXHentai.

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceComfortableGrid.kt
@@ -53,20 +53,13 @@ fun BrowseSourceComfortableGrid(
             val stateFlow = mangaList[index] ?: return@items
             val initialPair = stateFlow.value
             key(initialPair.first.url) {
-                val pair by stateFlow.collectAsState()
-                val manga = pair.first
-                val metadata = pair.second
-                // SY <--
-
-                BrowseSourceComfortableGridItem(
-                    manga = manga,
-                    // SY -->
-                    metadata = metadata,
-                    // SY <--
-                    onClick = { onMangaClick(manga) },
-                    onLongClick = { onMangaLongClick(manga) },
+                BrowseSourceComfortableGridItemWithState(
+                    stateFlow = stateFlow,
+                    onMangaClick = onMangaClick,
+                    onMangaLongClick = onMangaLongClick,
                 )
             }
+            // SY <--
         }
 
         if (mangaList.loadState.refresh is LoadState.Loading || mangaList.loadState.append is LoadState.Loading) {
@@ -75,6 +68,26 @@ fun BrowseSourceComfortableGrid(
             }
         }
     }
+}
+
+@Composable
+private fun BrowseSourceComfortableGridItemWithState(
+    stateFlow: StateFlow<Pair<Manga, RaisedSearchMetadata?>>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    val pair by stateFlow.collectAsState()
+    val manga = pair.first
+    val metadata = pair.second
+
+    BrowseSourceComfortableGridItem(
+        manga = manga,
+        // SY -->
+        metadata = metadata,
+        // SY <--
+        onClick = { onMangaClick(manga) },
+        onLongClick = { onMangaLongClick(manga) },
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceCompactGrid.kt
@@ -53,20 +53,13 @@ fun BrowseSourceCompactGrid(
             val stateFlow = mangaList[index] ?: return@items
             val initialPair = stateFlow.value
             key(initialPair.first.url) {
-                val pair by stateFlow.collectAsState()
-                val manga = pair.first
-                val metadata = pair.second
-                // SY <--
-
-                BrowseSourceCompactGridItem(
-                    manga = manga,
-                    // SY -->
-                    metadata = metadata,
-                    // SY <--
-                    onClick = { onMangaClick(manga) },
-                    onLongClick = { onMangaLongClick(manga) },
+                BrowseSourceCompactGridItemWithState(
+                    stateFlow = stateFlow,
+                    onMangaClick = onMangaClick,
+                    onMangaLongClick = onMangaLongClick,
                 )
             }
+            // SY <--
         }
 
         if (mangaList.loadState.refresh is LoadState.Loading || mangaList.loadState.append is LoadState.Loading) {
@@ -75,6 +68,26 @@ fun BrowseSourceCompactGrid(
             }
         }
     }
+}
+
+@Composable
+private fun BrowseSourceCompactGridItemWithState(
+    stateFlow: StateFlow<Pair<Manga, RaisedSearchMetadata?>>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    val pair by stateFlow.collectAsState()
+    val manga = pair.first
+    val metadata = pair.second
+
+    BrowseSourceCompactGridItem(
+        manga = manga,
+        // SY -->
+        metadata = metadata,
+        // SY <--
+        onClick = { onMangaClick(manga) },
+        onLongClick = { onMangaLongClick(manga) },
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
@@ -74,17 +74,10 @@ fun BrowseSourceEHentaiList(
             val stateFlow = mangaList[index] ?: return@items
             val initialPair = stateFlow.value
             key(initialPair.first.url) {
-                val pair by stateFlow.collectAsState()
-                val manga = pair.first
-                val metadata = pair.second
-
-                BrowseSourceEHentaiListItem(
-                    manga = manga,
-                    // SY -->
-                    metadata = metadata,
-                    // SY <--
-                    onClick = { onMangaClick(manga) },
-                    onLongClick = { onMangaLongClick(manga) },
+                BrowseSourceEHentaiListItemWithState(
+                    stateFlow = stateFlow,
+                    onMangaClick = onMangaClick,
+                    onMangaLongClick = onMangaLongClick,
                 )
             }
         }
@@ -95,6 +88,26 @@ fun BrowseSourceEHentaiList(
             }
         }
     }
+}
+
+@Composable
+private fun BrowseSourceEHentaiListItemWithState(
+    stateFlow: StateFlow<Pair<Manga, RaisedSearchMetadata?>>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    val pair by stateFlow.collectAsState()
+    val manga = pair.first
+    val metadata = pair.second
+
+    BrowseSourceEHentaiListItem(
+        manga = manga,
+        // SY -->
+        metadata = metadata,
+        // SY <--
+        onClick = { onMangaClick(manga) },
+        onLongClick = { onMangaLongClick(manga) },
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceList.kt
@@ -46,20 +46,13 @@ fun BrowseSourceList(
             val stateFlow = mangaList[index] ?: return@items
             val initialPair = stateFlow.value
             key(initialPair.first.url) {
-                val pair by stateFlow.collectAsState()
-                val manga = pair.first
-                val metadata = pair.second
-                // SY <--
-
-                BrowseSourceListItem(
-                    manga = manga,
-                    // SY -->
-                    metadata = metadata,
-                    // SY <--
-                    onClick = { onMangaClick(manga) },
-                    onLongClick = { onMangaLongClick(manga) },
+                BrowseSourceListItemWithState(
+                    stateFlow = stateFlow,
+                    onMangaClick = onMangaClick,
+                    onMangaLongClick = onMangaLongClick,
                 )
             }
+            // SY <--
         }
 
         item {
@@ -68,6 +61,26 @@ fun BrowseSourceList(
             }
         }
     }
+}
+
+@Composable
+private fun BrowseSourceListItemWithState(
+    stateFlow: StateFlow<Pair<Manga, RaisedSearchMetadata?>>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    val pair by stateFlow.collectAsState()
+    val manga = pair.first
+    val metadata = pair.second
+
+    BrowseSourceListItem(
+        manga = manga,
+        // SY -->
+        metadata = metadata,
+        // SY <--
+        onClick = { onMangaClick(manga) },
+        onLongClick = { onMangaLongClick(manga) },
+    )
 }
 
 @Composable


### PR DESCRIPTION
### Issue #1535 Fixed
Fixed a crash when scrolling through exhentai and loading new pages. The error was:
`java.lang.IllegalArgumentException: measure is called on a deactivated node`

### Root Cause
`collectAsState()` was called directly in the `items` block of `LazyVerticalGrid`/`LazyColumn` without proper scoping. When paging removed items during scrolling, the StateFlow collection could still be active while the composable node was deactivated, causing measurement on a deactivated node.

### Solution
Wrapped the state collection and item rendering in a key() block using the manga URL as the key. This ensures:
1. Proper composition lifecycle: when items are removed/replaced, the composable is reset
2. State collection cleanup: the state collection is disposed when items are removed
3. Stable key: using manga URL (unique identifier) instead of StateFlow reference

### Files Changed
* `BrowseSourceComfortableGrid.kt` - Comfortable grid display mode
* `BrowseSourceCompactGrid.kt` - Compact grid display mode
* `BrowseSourceList.kt` - List display mode
* `BrowseSourceEHentaiList.kt` - EHentai-specific list display mode
