### PR TITLE
Fix EH crash while browsing

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
@@ -17,9 +17,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -105,6 +109,13 @@ fun BrowseSourceEHentaiListItem(
     val overlayColor = MaterialTheme.colorScheme.background.copy(alpha = 0.66f)
 
     val context = LocalContext.current
+
+    var isActive by remember { mutableStateOf(false) }
+    DisposableEffect(Unit) {
+        isActive = true
+        onDispose { isActive = false }
+    }
+
     val languageText by produceState("", metadata) {
         value = withIOContext {
             val locale = SourceTagsUtil.getLocaleSourceUtil(
@@ -222,16 +233,18 @@ fun BrowseSourceEHentaiListItem(
                     verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
                     horizontalAlignment = Alignment.Start,
                 ) {
-                    ComposeStars(
-                        value = rating,
-                        config = RatingBarConfig().apply {
-                            isIndicator(true)
-                            numStars(5)
-                            size(18.dp)
-                            activeColor(Color(0xFF005ED7))
-                            inactiveColor(Color(0xE1E2ECFF))
-                        },
-                    )
+                    if (isActive) {
+                        ComposeStars(
+                            value = rating,
+                            config = RatingBarConfig().apply {
+                                isIndicator(true)
+                                numStars(5)
+                                size(18.dp)
+                                activeColor(Color(0xFF005ED7))
+                                inactiveColor(Color(0xE1E2ECFF))
+                            },
+                        )
+                    }
                     val color = genre?.first?.color
                     val res = genre?.second
                     Card(


### PR DESCRIPTION
This PR adds a lifecycle check to `ComposeStars` to prevent updating modifiers on a deactivated `LayoutNode`

I believe this is just a "band-aid" fix to the problem. The composable function from the library (`com.github.a914-gowtham:compose-ratingbar`) used for the star composable causes a side effect.

```kt
@Composable
fun ComposeStars(
    value: Float,
    config: RatingBarConfig
) {

    val ratingPerStar = 1f
    var remainingRating = value

    Row(modifier = Modifier
        .semantics { starRating = value }) {
        for (i in 1..config.numStars) {
            val starRating = when {
                remainingRating == 0f -> {
                    0f
                }
                remainingRating >= ratingPerStar -> {
                    remainingRating -= ratingPerStar // <- mutates a var outside `when` block which can cause unexpected recompositions
                    1f
                }
```
Replacing this function with a custom one that avoids this side-effect reveals another crash, `java.lang.IllegalStateException: Apply is called on deactivated node LayoutNode` 
([2026-01-01-debug.txt](https://github.com/user-attachments/files/24401788/2026-01-01-debug.txt) log for anyone interested), so a guard is necessary to continue using this library.

Also, not entirely sure why this started crashing only now, the compose version bump in commit 3724d79 perhaps?
 
 Closes #1535 