### PR TITLE
Soft deletion of chapters

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -74,9 +74,8 @@ class SyncChaptersWithSource(
                     .copy(mangaId = manga.id, sourceOrder = i.toLong())
             }
 
-        val dbChapters = getChaptersByMangaId.await(manga.id)
-        val dbChaptersIncludeDeleted =
-            chapterRepository.getChapterByMangaId(manga.id, includeDeleted = true)
+        val dbChaptersIncludeDeleted = chapterRepository.getChapterByMangaId(manga.id, includeDeleted = true)
+        val dbChapters = dbChaptersIncludeDeleted.filterNot { it.deleted }
 
         val newChapters = mutableListOf<Chapter>()
         val updatedChapters = mutableListOf<Chapter>()

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -61,31 +61,36 @@ class SyncChaptersWithSource(
         val now = ZonedDateTime.now()
         val nowMillis = now.toInstant().toEpochMilli()
 
-        val sourceChapters = rawSourceChapters
-            .distinctBy { it.url }
-            .mapIndexed { i, sChapter ->
+        val sourceChapters =
+            rawSourceChapters.distinctBy { it.url }.mapIndexed { i, sChapter ->
                 Chapter.create()
                     .copyFromSChapter(sChapter)
-                    .copy(name = with(ChapterSanitizer) { sChapter.name.sanitize(manga.title) })
+                    .copy(
+                        name =
+                        with(ChapterSanitizer) {
+                            sChapter.name.sanitize(manga.title)
+                        },
+                    )
                     .copy(mangaId = manga.id, sourceOrder = i.toLong())
             }
 
         val dbChapters = getChaptersByMangaId.await(manga.id)
-        val dbChaptersIncludeDeleted = chapterRepository.getChapterByMangaId(manga.id, includeDeleted = true)
+        val dbChaptersIncludeDeleted =
+            chapterRepository.getChapterByMangaId(manga.id, includeDeleted = true)
 
         val newChapters = mutableListOf<Chapter>()
         val updatedChapters = mutableListOf<Chapter>()
-        val chaptersToSoftDelete = dbChapters.filterNot { dbChapter ->
-            sourceChapters.any { sourceChapter ->
-                dbChapter.url == sourceChapter.url
+        val chaptersToSoftDelete =
+            dbChapters.filterNot { dbChapter ->
+                sourceChapters.any { sourceChapter -> dbChapter.url == sourceChapter.url }
             }
-        }
-        val chaptersToUndelete = dbChaptersIncludeDeleted.filter { dbChapter ->
-            dbChapter.deleted &&
-                sourceChapters.any { sourceChapter ->
-                    dbChapter.url == sourceChapter.url
-                }
-        }
+        val chaptersToUndelete =
+            dbChaptersIncludeDeleted.filter { dbChapter ->
+                dbChapter.deleted &&
+                    sourceChapters.any { sourceChapter ->
+                        dbChapter.url == sourceChapter.url
+                    }
+            }
 
         // Used to not set upload date of older chapters
         // to a higher value than newer chapters
@@ -102,48 +107,54 @@ class SyncChaptersWithSource(
             }
 
             // Recognize chapter number for the chapter.
-            val chapterNumber = ChapterRecognition.parseChapterNumber(
-                manga.title,
-                chapter.name,
-                chapter.chapterNumber,
-            )
+            val chapterNumber =
+                ChapterRecognition.parseChapterNumber(
+                    manga.title,
+                    chapter.name,
+                    chapter.chapterNumber,
+                )
             chapter = chapter.copy(chapterNumber = chapterNumber)
 
-            val existingChapter = dbChapters.find { it.url == chapter.url }
-                ?: dbChaptersIncludeDeleted.find { it.url == chapter.url && it.deleted }
+            val existingChapter =
+                dbChapters.find { it.url == chapter.url }
+                    ?: dbChaptersIncludeDeleted.find { it.url == chapter.url && it.deleted }
 
             if (existingChapter == null) {
                 // Chapter is new, so add it
-                val toAddChapter = if (chapter.dateUpload == 0L) {
-                    val altDateUpload = if (maxSeenUploadDate == 0L) nowMillis else maxSeenUploadDate
-                    chapter.copy(dateUpload = altDateUpload)
-                } else {
-                    maxSeenUploadDate = max(maxSeenUploadDate, sourceChapter.dateUpload)
-                    chapter
-                }
+                val toAddChapter =
+                    if (chapter.dateUpload == 0L) {
+                        val altDateUpload =
+                            if (maxSeenUploadDate == 0L) nowMillis else maxSeenUploadDate
+                        chapter.copy(dateUpload = altDateUpload)
+                    } else {
+                        maxSeenUploadDate = max(maxSeenUploadDate, sourceChapter.dateUpload)
+                        chapter
+                    }
                 newChapters.add(toAddChapter)
             } else {
                 // Chapter exists in DB (deleted or not), check for updates
                 if (shouldUpdateDbChapter.await(existingChapter, chapter)) {
-                    val shouldRenameChapter = downloadProvider.isChapterDirNameChanged(existingChapter, chapter) &&
-                        downloadManager.isChapterDownloaded(
-                            existingChapter.name,
-                            existingChapter.scanlator,
-                            existingChapter.url,
-                            /* SY --> */ manga.ogTitle /* SY <-- */,
-                            manga.source,
-                        )
+                    val shouldRenameChapter =
+                        downloadProvider.isChapterDirNameChanged(existingChapter, chapter) &&
+                            downloadManager.isChapterDownloaded(
+                                existingChapter.name,
+                                existingChapter.scanlator,
+                                existingChapter.url,
+                                /* SY --> */ manga.ogTitle /* SY <-- */,
+                                manga.source,
+                            )
 
                     if (shouldRenameChapter) {
                         downloadManager.renameChapter(source, manga, existingChapter, chapter)
                     }
 
-                    var toChangeChapter = existingChapter.copy(
-                        name = chapter.name,
-                        chapterNumber = chapter.chapterNumber,
-                        scanlator = chapter.scanlator,
-                        sourceOrder = chapter.sourceOrder,
-                    )
+                    var toChangeChapter =
+                        existingChapter.copy(
+                            name = chapter.name,
+                            chapterNumber = chapter.chapterNumber,
+                            scanlator = chapter.scanlator,
+                            sourceOrder = chapter.sourceOrder,
+                        )
 
                     if (chapter.dateUpload != 0L) {
                         toChangeChapter = toChangeChapter.copy(dateUpload = chapter.dateUpload)
@@ -154,7 +165,11 @@ class SyncChaptersWithSource(
         }
 
         // Return if there's nothing to add, delete, or update to avoid unnecessary db transactions.
-        if (newChapters.isEmpty() && chaptersToSoftDelete.isEmpty() && chaptersToUndelete.isEmpty() && updatedChapters.isEmpty()) {
+        if (newChapters.isEmpty() &&
+            chaptersToSoftDelete.isEmpty() &&
+            chaptersToUndelete.isEmpty() &&
+            updatedChapters.isEmpty()
+        ) {
             if (manualFetch || manga.fetchInterval == 0 || manga.nextUpdate < fetchWindow.first) {
                 updateManga.awaitUpdateFetchInterval(
                     manga,
@@ -171,11 +186,12 @@ class SyncChaptersWithSource(
         val deletedReadChapterNumbers = TreeSet<Double>()
         val deletedBookmarkedChapterNumbers = TreeSet<Double>()
 
-        val readChapterNumbers = dbChapters
-            .asSequence()
-            .filter { it.read && it.isRecognizedNumber }
-            .map { it.chapterNumber }
-            .toSet()
+        val readChapterNumbers =
+            dbChapters
+                .asSequence()
+                .filter { it.read && it.isRecognizedNumber }
+                .map { it.chapterNumber }
+                .toSet()
 
         chaptersToSoftDelete.forEach { chapter ->
             if (chapter.read) deletedReadChapterNumbers.add(chapter.chapterNumber)
@@ -183,39 +199,54 @@ class SyncChaptersWithSource(
             deletedChapterNumbers.add(chapter.chapterNumber)
         }
 
-        val deletedChapterNumberDateFetchMap = chaptersToSoftDelete.sortedByDescending { it.dateFetch }
-            .associate { it.chapterNumber to it.dateFetch }
+        val deletedChapterNumberDateFetchMap =
+            chaptersToSoftDelete.sortedByDescending { it.dateFetch }.associate {
+                it.chapterNumber to it.dateFetch
+            }
 
-        val markDuplicateAsRead = libraryPreferences.markDuplicateReadChapterAsRead().get()
-            .contains(LibraryPreferences.MARK_DUPLICATE_CHAPTER_READ_NEW)
+        val markDuplicateAsRead =
+            libraryPreferences
+                .markDuplicateReadChapterAsRead()
+                .get()
+                .contains(LibraryPreferences.MARK_DUPLICATE_CHAPTER_READ_NEW)
 
-        // Date fetch is set in such a way that the upper ones will have bigger value than the lower ones
+        // Date fetch is set in such a way that the upper ones will have bigger value than the lower
+        // ones
         // Sources MUST return the chapters from most to less recent, which is common.
         var itemCount = newChapters.size
-        var updatedToAdd = newChapters.map { toAddItem ->
-            var chapter = toAddItem.copy(dateFetch = nowMillis + itemCount--)
+        var updatedToAdd =
+            newChapters.map { toAddItem ->
+                var chapter = toAddItem.copy(dateFetch = nowMillis + itemCount--)
 
-            if (chapter.chapterNumber in readChapterNumbers && markDuplicateAsRead) {
+                if (chapter.chapterNumber in readChapterNumbers && markDuplicateAsRead) {
+                    changedOrDuplicateReadUrls.add(chapter.url)
+                    chapter = chapter.copy(read = true)
+                }
+
+                if (!chapter.isRecognizedNumber ||
+                    chapter.chapterNumber !in deletedChapterNumbers
+                ) {
+                    return@map chapter
+                }
+
+                chapter =
+                    chapter.copy(
+                        read = chapter.chapterNumber in deletedReadChapterNumbers,
+                        bookmark =
+                        chapter.chapterNumber in
+                            deletedBookmarkedChapterNumbers,
+                    )
+
+                // Try to to use the fetch date of the original entry to not pollute 'Updates'
+                // tab
+                deletedChapterNumberDateFetchMap[chapter.chapterNumber]?.let {
+                    chapter = chapter.copy(dateFetch = it)
+                }
+
                 changedOrDuplicateReadUrls.add(chapter.url)
-                chapter = chapter.copy(read = true)
+
+                chapter
             }
-
-            if (!chapter.isRecognizedNumber || chapter.chapterNumber !in deletedChapterNumbers) return@map chapter
-
-            chapter = chapter.copy(
-                read = chapter.chapterNumber in deletedReadChapterNumbers,
-                bookmark = chapter.chapterNumber in deletedBookmarkedChapterNumbers,
-            )
-
-            // Try to to use the fetch date of the original entry to not pollute 'Updates' tab
-            deletedChapterNumberDateFetchMap[chapter.chapterNumber]?.let {
-                chapter = chapter.copy(dateFetch = it)
-            }
-
-            changedOrDuplicateReadUrls.add(chapter.url)
-
-            chapter
-        }
 
         // --> EXH (carry over reading progress)
         if (manga.isEhBasedManga()) {
@@ -223,13 +254,14 @@ class SyncChaptersWithSource(
             if (finalAdded.isNotEmpty()) {
                 val max = dbChapters.maxOfOrNull { it.lastPageRead }
                 if (max != null && max > 0) {
-                    updatedToAdd = updatedToAdd.map {
-                        if (it.url !in changedOrDuplicateReadUrls) {
-                            it.copy(lastPageRead = max)
-                        } else {
-                            it
+                    updatedToAdd =
+                        updatedToAdd.map {
+                            if (it.url !in changedOrDuplicateReadUrls) {
+                                it.copy(lastPageRead = max)
+                            } else {
+                                it
+                            }
                         }
-                    }
                 }
             }
         }
@@ -241,9 +273,8 @@ class SyncChaptersWithSource(
         }
 
         if (chaptersToUndelete.isNotEmpty()) {
-            val chapterUpdates = chaptersToUndelete.map {
-                it.toChapterUpdate().copy(deleted = false)
-            }
+            val chapterUpdates =
+                chaptersToUndelete.map { it.toChapterUpdate().copy(deleted = false) }
             updateChapter.awaitAll(chapterUpdates)
         }
 
@@ -263,6 +294,8 @@ class SyncChaptersWithSource(
 
         val excludedScanlators = getExcludedScanlators.await(manga.id).toHashSet()
 
-        return updatedToAdd.filterNot { it.url in changedOrDuplicateReadUrls || it.scanlator in excludedScanlators }
+        return updatedToAdd.filterNot {
+            it.url in changedOrDuplicateReadUrls || it.scanlator in excludedScanlators
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -71,13 +71,20 @@ class SyncChaptersWithSource(
             }
 
         val dbChapters = getChaptersByMangaId.await(manga.id)
+        val dbChaptersIncludeDeleted = chapterRepository.getChapterByMangaId(manga.id, includeDeleted = true)
 
         val newChapters = mutableListOf<Chapter>()
         val updatedChapters = mutableListOf<Chapter>()
-        val removedChapters = dbChapters.filterNot { dbChapter ->
+        val chaptersToSoftDelete = dbChapters.filterNot { dbChapter ->
             sourceChapters.any { sourceChapter ->
                 dbChapter.url == sourceChapter.url
             }
+        }
+        val chaptersToUndelete = dbChaptersIncludeDeleted.filter { dbChapter ->
+            dbChapter.deleted &&
+                sourceChapters.any { sourceChapter ->
+                    dbChapter.url == sourceChapter.url
+                }
         }
 
         // Used to not set upload date of older chapters
@@ -102,9 +109,11 @@ class SyncChaptersWithSource(
             )
             chapter = chapter.copy(chapterNumber = chapterNumber)
 
-            val dbChapter = dbChapters.find { it.url == chapter.url }
+            val existingChapter = dbChapters.find { it.url == chapter.url }
+                ?: dbChaptersIncludeDeleted.find { it.url == chapter.url && it.deleted }
 
-            if (dbChapter == null) {
+            if (existingChapter == null) {
+                // Chapter is new, so add it
                 val toAddChapter = if (chapter.dateUpload == 0L) {
                     val altDateUpload = if (maxSeenUploadDate == 0L) nowMillis else maxSeenUploadDate
                     chapter.copy(dateUpload = altDateUpload)
@@ -114,21 +123,22 @@ class SyncChaptersWithSource(
                 }
                 newChapters.add(toAddChapter)
             } else {
-                if (shouldUpdateDbChapter.await(dbChapter, chapter)) {
-                    val shouldRenameChapter = downloadProvider.isChapterDirNameChanged(dbChapter, chapter) &&
+                // Chapter exists in DB (deleted or not), check for updates
+                if (shouldUpdateDbChapter.await(existingChapter, chapter)) {
+                    val shouldRenameChapter = downloadProvider.isChapterDirNameChanged(existingChapter, chapter) &&
                         downloadManager.isChapterDownloaded(
-                            dbChapter.name,
-                            dbChapter.scanlator,
-                            dbChapter.url,
+                            existingChapter.name,
+                            existingChapter.scanlator,
+                            existingChapter.url,
                             /* SY --> */ manga.ogTitle /* SY <-- */,
                             manga.source,
                         )
 
                     if (shouldRenameChapter) {
-                        downloadManager.renameChapter(source, manga, dbChapter, chapter)
+                        downloadManager.renameChapter(source, manga, existingChapter, chapter)
                     }
 
-                    var toChangeChapter = dbChapter.copy(
+                    var toChangeChapter = existingChapter.copy(
                         name = chapter.name,
                         chapterNumber = chapter.chapterNumber,
                         scanlator = chapter.scanlator,
@@ -144,7 +154,7 @@ class SyncChaptersWithSource(
         }
 
         // Return if there's nothing to add, delete, or update to avoid unnecessary db transactions.
-        if (newChapters.isEmpty() && removedChapters.isEmpty() && updatedChapters.isEmpty()) {
+        if (newChapters.isEmpty() && chaptersToSoftDelete.isEmpty() && chaptersToUndelete.isEmpty() && updatedChapters.isEmpty()) {
             if (manualFetch || manga.fetchInterval == 0 || manga.nextUpdate < fetchWindow.first) {
                 updateManga.awaitUpdateFetchInterval(
                     manga,
@@ -167,13 +177,13 @@ class SyncChaptersWithSource(
             .map { it.chapterNumber }
             .toSet()
 
-        removedChapters.forEach { chapter ->
+        chaptersToSoftDelete.forEach { chapter ->
             if (chapter.read) deletedReadChapterNumbers.add(chapter.chapterNumber)
             if (chapter.bookmark) deletedBookmarkedChapterNumbers.add(chapter.chapterNumber)
             deletedChapterNumbers.add(chapter.chapterNumber)
         }
 
-        val deletedChapterNumberDateFetchMap = removedChapters.sortedByDescending { it.dateFetch }
+        val deletedChapterNumberDateFetchMap = chaptersToSoftDelete.sortedByDescending { it.dateFetch }
             .associate { it.chapterNumber to it.dateFetch }
 
         val markDuplicateAsRead = libraryPreferences.markDuplicateReadChapterAsRead().get()
@@ -225,9 +235,16 @@ class SyncChaptersWithSource(
         }
         // <-- EXH
 
-        if (removedChapters.isNotEmpty()) {
-            val toDeleteIds = removedChapters.map { it.id }
-            chapterRepository.removeChaptersWithIds(toDeleteIds)
+        if (chaptersToSoftDelete.isNotEmpty()) {
+            val toSoftDeleteIds = chaptersToSoftDelete.map { it.id }
+            chapterRepository.softDeleteChaptersWithIds(toSoftDeleteIds)
+        }
+
+        if (chaptersToUndelete.isNotEmpty()) {
+            val chapterUpdates = chaptersToUndelete.map {
+                it.toChapterUpdate().copy(deleted = false)
+            }
+            updateChapter.awaitAll(chapterUpdates)
         }
 
         if (updatedToAdd.isNotEmpty()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -71,10 +71,11 @@ class MangaBackupCreator(
         }
 
         if (options.chapters) {
-            // Backup all the chapters
+            // Backup all the chapters, including deleted ones for sync
             handler.awaitList {
                 chaptersQueries.getChaptersByMangaId(
                     mangaId = manga.id,
+                    includeDeleted = 1, // include soft-deleted chapters in backups
                     applyScanlatorFilter = 0, // false
                     mapper = backupChapterMapper,
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -22,6 +22,7 @@ data class BackupChapter(
     @ProtoNumber(10) var sourceOrder: Long = 0,
     @ProtoNumber(11) var lastModifiedAt: Long = 0,
     @ProtoNumber(12) var version: Long = 0,
+    @ProtoNumber(13) var deleted: Boolean = false,
 ) {
     fun toChapterImpl(): Chapter {
         return Chapter.create().copy(
@@ -37,6 +38,7 @@ data class BackupChapter(
             sourceOrder = this@BackupChapter.sourceOrder,
             lastModifiedAt = this@BackupChapter.lastModifiedAt,
             version = this@BackupChapter.version,
+            deleted = this@BackupChapter.deleted,
         )
     }
 }
@@ -57,6 +59,7 @@ val backupChapterMapper = {
         lastModifiedAt: Long,
         version: Long,
         _: Long,
+        deleted: Boolean,
     ->
     BackupChapter(
         url = url,
@@ -71,5 +74,6 @@ val backupChapterMapper = {
         sourceOrder = sourceOrder,
         lastModifiedAt = lastModifiedAt,
         version = version,
+        deleted = deleted,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -176,7 +176,7 @@ class MangaRestorer(
     }
 
     private suspend fun restoreChapters(manga: Manga, backupChapters: List<BackupChapter>) {
-        val dbChaptersByUrl = getChaptersByMangaId.await(manga.id)
+        val dbChaptersByUrl = getChaptersByMangaId.await(manga.id, includeDeleted = true)
             .associateBy { it.url }
 
         val (existingChapters, newChapters) = backupChapters

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -260,6 +260,9 @@ class MangaRestorer(
                     chapterId = chapter.id,
                     version = chapter.version,
                     isSyncing = 1,
+                    // KMK -->
+                    deleted = chapter.deleted,
+                    // KMK <--
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -24,6 +24,7 @@ import tachiyomi.data.DatabaseHandler
 import tachiyomi.data.manga.MangaMapper.mapManga
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.applyFilter
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
@@ -242,7 +243,13 @@ class SyncManager(
     }
 
     private suspend fun isMangaDifferent(localManga: Manga, remoteManga: BackupManga): Boolean {
-        val localChapters = handler.await { chaptersQueries.getChaptersByMangaId(localManga.id, 0).executeAsList() }
+        val localChapters = handler.await {
+            chaptersQueries.getChaptersByMangaId(
+                mangaId = localManga.id,
+                includeDeleted = 1,
+                applyScanlatorFilter = 0,
+            ).executeAsList()
+        }
         val localCategories = getCategories.await(localManga.id).map { it.order }
 
         if (areChaptersDifferent(localChapters, remoteManga.chapters)) {

--- a/app/src/test/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSourceTest.kt
+++ b/app/src/test/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSourceTest.kt
@@ -1,0 +1,632 @@
+package eu.kanade.domain.chapter.interactor
+
+import eu.kanade.domain.manga.interactor.GetExcludedScanlators
+import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.model.SChapter
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.interactor.ShouldUpdateDbChapter
+import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.chapter.repository.ChapterRepository
+import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.manga.model.Manga
+
+@Execution(ExecutionMode.CONCURRENT)
+@DisplayName("SyncChaptersWithSource - Soft Deletion and Undeletion Tests")
+class SyncChaptersWithSourceTest {
+
+    private lateinit var syncChaptersWithSource: SyncChaptersWithSource
+    private lateinit var downloadManager: DownloadManager
+    private lateinit var downloadProvider: DownloadProvider
+    private lateinit var chapterRepository: ChapterRepository
+    private lateinit var shouldUpdateDbChapter: ShouldUpdateDbChapter
+    private lateinit var updateManga: UpdateManga
+    private lateinit var updateChapter: UpdateChapter
+    private lateinit var getChaptersByMangaId: GetChaptersByMangaId
+    private lateinit var getExcludedScanlators: GetExcludedScanlators
+    private lateinit var libraryPreferences: LibraryPreferences
+
+    private val testManga = Manga.create().copy(
+        id = 1L,
+        ogTitle = "Test Manga",
+        source = 1L,
+    )
+
+    private val testSource = mockk<Source>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        downloadManager = mockk(relaxed = true)
+        downloadProvider = mockk(relaxed = true)
+        chapterRepository = mockk(relaxed = true)
+        shouldUpdateDbChapter = mockk(relaxed = true)
+        updateManga = mockk(relaxed = true)
+        updateChapter = mockk(relaxed = true)
+        getChaptersByMangaId = mockk(relaxed = true)
+        getExcludedScanlators = mockk(relaxed = true)
+        libraryPreferences = mockk(relaxed = true)
+
+        // Default mock behaviors
+        coEvery { updateManga.awaitUpdateFetchInterval(any(), any(), any()) } returns true
+        coEvery { updateManga.awaitUpdateLastUpdate(any()) } returns true
+        coEvery { chapterRepository.addAll(any()) } answers { firstArg() }
+        coEvery { getExcludedScanlators.await(any()) } returns emptySet()
+        coEvery { libraryPreferences.markDuplicateReadChapterAsRead() } returns mockk {
+            coEvery { get() } returns emptySet<String>()
+        }
+
+        syncChaptersWithSource = SyncChaptersWithSource(
+            downloadManager,
+            downloadProvider,
+            chapterRepository,
+            shouldUpdateDbChapter,
+            updateManga,
+            updateChapter,
+            getChaptersByMangaId,
+            getExcludedScanlators,
+            libraryPreferences,
+        )
+    }
+
+    @Nested
+    @DisplayName("Soft-deleted chapters handling")
+    inner class SoftDeletedChaptersHandling {
+
+        @Test
+        fun `chapters that don't reappear in source are soft-deleted`() = runBlocking {
+            // Arrange: DB has a chapter, source doesn't
+            val dbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                name = "Chapter 1",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+            // Mock the repository method directly since SyncChaptersWithSource calls it
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(dbChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            val sourceChapters = emptyList<SChapter>()
+
+            // Act
+            syncChaptersWithSource.await(sourceChapters, testManga, testSource)
+
+            // Assert: verify soft delete was called with correct chapter id
+            coVerify { chapterRepository.softDeleteChaptersWithIds(listOf(dbChapter.id)) }
+        }
+
+        @Test
+        fun `chapters that reappear in source are undeleted`() = runBlocking {
+            // Arrange: DB has a deleted chapter, source has it again
+            val dbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                name = "Chapter 1",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(dbChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: verify update was called to undelete the chapter
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.any { it.id == dbChapter.id && it.deleted == false }
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `multiple chapters can be undeleted in same sync`() = runBlocking {
+            // Arrange: DB has multiple deleted chapters, source has them all
+            val dbChapter1 = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+            val dbChapter2 = Chapter.create().copy(
+                id = 2L,
+                url = "chapter2",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter1 = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+            val sourceChapter2 = SChapter.create().apply {
+                url = "chapter2"
+                name = "Chapter 2"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(
+                dbChapter1,
+                dbChapter2,
+            )
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter1, sourceChapter2),
+                testManga,
+                testSource,
+            )
+
+            // Assert
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.size == 2 && updates.all { it.deleted == false }
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Chapters needing undeletion and metadata updates")
+    inner class UndeleteWithMetadataUpdates {
+
+        @Test
+        fun `undeleted chapter gets metadata updated from source`() = runBlocking {
+            // Arrange: Soft-deleted chapter reappears with updated metadata
+            val dbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                name = "Old Name",
+                scanlator = "Old Group",
+                mangaId = testManga.id,
+                deleted = true,
+                chapterNumber = 1.0,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "New Name"
+                scanlator = "New Group"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(dbChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns true
+            coEvery { downloadProvider.isChapterDirNameChanged(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: Verify both update for undelete and metadata update
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        // Should have undeletion
+                        updates.any { it.id == dbChapter.id && it.deleted == false }
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `undeleted chapter preserves non-metadata fields like read status`() = runBlocking {
+            // Arrange
+            val dbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                name = "Chapter 1",
+                mangaId = testManga.id,
+                deleted = true,
+                read = true,
+                lastPageRead = 50L,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(dbChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: verify deleted is set to false but read/lastPageRead are preserved
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.any { update ->
+                            update.id == dbChapter.id && update.deleted == false
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases and ordering")
+    inner class EdgeCasesAndOrdering {
+
+        @Test
+        fun `soft deletion happens before new chapter insertion`() = runBlocking {
+            // Arrange: A chapter is removed from source while a new one is added
+            val existingDbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "old_chapter",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val newSourceChapter = SChapter.create().apply {
+                url = "new_chapter"
+                name = "New Chapter"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(existingDbChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(newSourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: soft delete should be called, and new chapter should be added
+            coVerify { chapterRepository.softDeleteChaptersWithIds(listOf(existingDbChapter.id)) }
+            coVerify { chapterRepository.addAll(any()) }
+        }
+
+        @Test
+        fun `only deleted chapters are passed to undeletion logic`() = runBlocking {
+            // Arrange: Mix of deleted and non-deleted chapters in DB
+            val nonDeletedChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val deletedChapter = Chapter.create().copy(
+                id = 2L,
+                url = "chapter2",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter1 = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+            val sourceChapter2 = SChapter.create().apply {
+                url = "chapter2"
+                name = "Chapter 2"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(
+                nonDeletedChapter,
+                deletedChapter,
+            )
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter1, sourceChapter2),
+                testManga,
+                testSource,
+            )
+
+            // Assert: Only the deleted chapter should be undeleted
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.size == 1 && updates.all { it.id == deletedChapter.id && it.deleted == false }
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `soft deletion and undeletion don't interfere with each other`() = runBlocking {
+            // Arrange: One chapter gets deleted, another gets undeleted, in same sync
+            val toDeleteChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter_to_delete",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val toUndeleteChapter = Chapter.create().copy(
+                id = 2L,
+                url = "chapter_to_undelete",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter_to_undelete"
+                name = "Restored Chapter"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(
+                toDeleteChapter,
+                toUndeleteChapter,
+            )
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: Both operations should happen
+            coVerify { chapterRepository.softDeleteChaptersWithIds(listOf(toDeleteChapter.id)) }
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.any { it.id == toUndeleteChapter.id && it.deleted == false }
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `deleted chapter is matched by URL during undeletion`() = runBlocking {
+            // Arrange: Verify URL is used for matching deleted chapters
+            val deletedChapter1 = Chapter.create().copy(
+                id = 1L,
+                url = "chapter_A",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val deletedChapter2 = Chapter.create().copy(
+                id = 2L,
+                url = "chapter_B",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter_B"
+                name = "Chapter B"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(
+                deletedChapter1,
+                deletedChapter2,
+            )
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: Only chapter with matching URL should be undeleted
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.size == 1 &&
+                            updates.first().id == deletedChapter2.id &&
+                            updates.first().deleted == false
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `no operations occur when nothing needs to sync`() = runBlocking {
+            // Arrange: DB and source are identical
+            val chapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                name = "Chapter 1",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(chapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: No deletion, undeletion, or update operations
+            coVerify(exactly = 0) { chapterRepository.softDeleteChaptersWithIds(any()) }
+            coVerify(exactly = 0) { updateChapter.awaitAll(any()) }
+            coVerify(exactly = 0) { chapterRepository.addAll(any()) }
+        }
+
+        @Test
+        fun `deleted chapters are excluded from normal processing logic`() = runBlocking {
+            // Arrange: Ensure deleted chapters don't get treated as "chapters to soft delete"
+            val deletedChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(deletedChapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: The deleted chapter should NOT be soft-deleted again (already deleted)
+            // Only undeletion should happen
+            coVerify(exactly = 0) { chapterRepository.softDeleteChaptersWithIds(any()) }
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        updates.any { it.id == deletedChapter.id && it.deleted == false }
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration scenarios")
+    inner class IntegrationScenarios {
+
+        @Test
+        fun `complex scenario with new, updated, deleted and undeleted chapters`() = runBlocking {
+            // Arrange: Complex scenario with all types of changes
+            val newSourceChapter = SChapter.create().apply {
+                url = "new_chapter"
+                name = "New Chapter"
+            }
+
+            val updatedSourceChapter = SChapter.create().apply {
+                url = "chapter_to_update"
+                name = "Updated Chapter Name"
+            }
+
+            val undeleteSourceChapter = SChapter.create().apply {
+                url = "chapter_to_undelete"
+                name = "Restored Chapter"
+            }
+
+            val existingDbChapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter_to_update",
+                name = "Old Chapter Name",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val deletedDbChapter = Chapter.create().copy(
+                id = 2L,
+                url = "chapter_to_undelete",
+                name = "Restored Chapter",
+                mangaId = testManga.id,
+                deleted = true,
+            )
+
+            val toBeDeletedDbChapter = Chapter.create().copy(
+                id = 3L,
+                url = "chapter_to_delete",
+                name = "To Delete",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(
+                existingDbChapter,
+                deletedDbChapter,
+                toBeDeletedDbChapter,
+            )
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+            coEvery { downloadProvider.isChapterDirNameChanged(any(), any()) } returns false
+            coEvery { chapterRepository.addAll(any()) } answers { firstArg() }
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(newSourceChapter, updatedSourceChapter, undeleteSourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert
+            coVerify { chapterRepository.softDeleteChaptersWithIds(listOf(toBeDeletedDbChapter.id)) }
+            coVerify {
+                updateChapter.awaitAll(
+                    match { updates ->
+                        // Check that undelete happened
+                        updates.any { it.id == deletedDbChapter.id && it.deleted == false }
+                    },
+                )
+            }
+            coVerify { chapterRepository.addAll(any()) } // new chapters added
+        }
+
+        @Test
+        fun `fetch interval is updated regardless of whether chapters changed`() = runBlocking {
+            // Arrange: Even with no chapter changes, fetch interval should update
+            val chapter = Chapter.create().copy(
+                id = 1L,
+                url = "chapter1",
+                mangaId = testManga.id,
+                deleted = false,
+            )
+
+            val sourceChapter = SChapter.create().apply {
+                url = "chapter1"
+                name = "Chapter 1"
+            }
+
+            coEvery { chapterRepository.getChapterByMangaId(testManga.id, any(), includeDeleted = true) } returns listOf(chapter)
+            coEvery { shouldUpdateDbChapter.await(any(), any()) } returns false
+
+            // Act
+            syncChaptersWithSource.await(
+                listOf(sourceChapter),
+                testManga,
+                testSource,
+            )
+
+            // Assert: fetch interval should still be updated on manual fetch
+            coVerify { updateManga.awaitUpdateFetchInterval(any(), any(), any()) }
+        }
+    }
+}

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterMapper.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterMapper.kt
@@ -20,6 +20,7 @@ object ChapterMapper {
         version: Long,
         @Suppress("UNUSED_PARAMETER")
         isSyncing: Long,
+        deleted: Boolean,
     ): Chapter = Chapter(
         id = id,
         mangaId = mangaId,
@@ -35,5 +36,6 @@ object ChapterMapper {
         scanlator = scanlator,
         lastModifiedAt = lastModifiedAt,
         version = version,
+        deleted = deleted,
     )
 }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -146,11 +146,12 @@ class ChapterRepositoryImpl(
         }
     }
 
-    override suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long): Chapter? {
+    override suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long, includeDeleted: Boolean): Chapter? {
         return handler.awaitOneOrNull {
             chaptersQueries.getChapterByUrlAndMangaId(
                 url,
                 mangaId,
+                includeDeleted.toLong(),
                 ChapterMapper::mapChapter,
             )
         }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -126,7 +126,9 @@ class ChapterRepositoryImpl(
     }
 
     override suspend fun getChapterById(id: Long): Chapter? {
-        return handler.awaitOneOrNull { chaptersQueries.getChapterById(id, ChapterMapper::mapChapter) }
+        return handler.awaitOneOrNull {
+            chaptersQueries.getChapterById(id, ChapterMapper::mapChapter)
+        }
     }
 
     override suspend fun getChapterByMangaIdAsFlow(
@@ -159,7 +161,10 @@ class ChapterRepositoryImpl(
         return handler.awaitList { chaptersQueries.getChapterByUrl(url, ChapterMapper::mapChapter) }
     }
 
-    override suspend fun getMergedChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean): List<Chapter> {
+    override suspend fun getMergedChapterByMangaId(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean,
+    ): List<Chapter> {
         return handler.awaitList {
             chaptersQueries.getMergedChaptersByMangaId(
                 mangaId,

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -103,8 +103,6 @@ class ChapterRepositoryImpl(
             )
         }
     }
-        }
-    }
 
     override suspend fun getScanlatorsByMangaId(mangaId: Long): List<String> {
         return handler.awaitList {
@@ -143,8 +141,6 @@ class ChapterRepositoryImpl(
                 applyScanlatorFilter = applyScanlatorFilter.toLong(),
                 mapper = ChapterMapper::mapChapter,
             )
-        }
-    }
         }
     }
 

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -67,6 +67,7 @@ class ChapterRepositoryImpl(
                     chapterId = chapterUpdate.id,
                     version = chapterUpdate.version,
                     isSyncing = 0,
+                    deleted = chapterUpdate.deleted,
                 )
             }
         }
@@ -80,9 +81,28 @@ class ChapterRepositoryImpl(
         }
     }
 
-    override suspend fun getChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean): List<Chapter> {
+    override suspend fun softDeleteChaptersWithIds(chapterIds: List<Long>) {
+        try {
+            handler.await { chaptersQueries.softDeleteChaptersWithIds(chapterIds) }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
+
+    override suspend fun getChapterByMangaId(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean,
+        includeDeleted: Boolean,
+    ): List<Chapter> {
         return handler.awaitList {
-            chaptersQueries.getChaptersByMangaId(mangaId, applyScanlatorFilter.toLong(), ChapterMapper::mapChapter)
+            chaptersQueries.getChaptersByMangaId(
+                mangaId = mangaId,
+                includeDeleted = includeDeleted.toLong(),
+                applyScanlatorFilter = applyScanlatorFilter.toLong(),
+                mapper = ChapterMapper::mapChapter,
+            )
+        }
+    }
         }
     }
 
@@ -111,9 +131,20 @@ class ChapterRepositoryImpl(
         return handler.awaitOneOrNull { chaptersQueries.getChapterById(id, ChapterMapper::mapChapter) }
     }
 
-    override suspend fun getChapterByMangaIdAsFlow(mangaId: Long, applyScanlatorFilter: Boolean): Flow<List<Chapter>> {
+    override suspend fun getChapterByMangaIdAsFlow(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean,
+        includeDeleted: Boolean,
+    ): Flow<List<Chapter>> {
         return handler.subscribeToList {
-            chaptersQueries.getChaptersByMangaId(mangaId, applyScanlatorFilter.toLong(), ChapterMapper::mapChapter)
+            chaptersQueries.getChaptersByMangaId(
+                mangaId = mangaId,
+                includeDeleted = includeDeleted.toLong(),
+                applyScanlatorFilter = applyScanlatorFilter.toLong(),
+                mapper = ChapterMapper::mapChapter,
+            )
+        }
+    }
         }
     }
 

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -93,7 +93,7 @@ SELECT *
 FROM chapters
 WHERE url = :chapterUrl
 AND manga_id = :mangaId
-AND deleted = 0;
+AND (:includeDeleted = 1 OR deleted = 0);
 
 getMergedChaptersByMangaId:
 SELECT C.*

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -152,8 +152,6 @@ SET manga_id = coalesce(:mangaId, manga_id),
     deleted = coalesce(:deleted, deleted)
 WHERE _id = :chapterId;
 
--- removed getChaptersByMangaIdIncludeDeleted: merged into getChaptersByMangaId with :includeDeleted flag
-
 softDeleteChaptersWithIds:
 UPDATE chapters
 SET deleted = 1

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -16,6 +16,7 @@ CREATE TABLE chapters(
     last_modified_at INTEGER NOT NULL DEFAULT 0,
     version INTEGER NOT NULL DEFAULT 0,
     is_syncing INTEGER NOT NULL DEFAULT 0,
+    deleted INTEGER AS Boolean NOT NULL DEFAULT 0,
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE
 );
@@ -61,6 +62,9 @@ ON C.manga_id = ES.manga_id
 AND C.scanlator = ES.scanlator
 WHERE C.manga_id = :mangaId
 AND (
+    :includeDeleted = 1 OR C.deleted = 0
+)
+AND (
     :applyScanlatorFilter = 0
     OR ES.scanlator IS NULL
 );
@@ -68,24 +72,28 @@ AND (
 getScanlatorsByMangaId:
 SELECT scanlator
 FROM chapters
-WHERE manga_id = :mangaId;
+WHERE manga_id = :mangaId
+AND deleted = 0;
 
 getBookmarkedChaptersByMangaId:
 SELECT *
 FROM chapters
 WHERE bookmark
-AND manga_id = :mangaId;
+AND manga_id = :mangaId
+AND deleted = 0;
 
 getChapterByUrl:
 SELECT *
 FROM chapters
-WHERE url = :chapterUrl;
+WHERE url = :chapterUrl
+AND deleted = 0;
 
 getChapterByUrlAndMangaId:
 SELECT *
 FROM chapters
 WHERE url = :chapterUrl
-AND manga_id = :mangaId;
+AND manga_id = :mangaId
+AND deleted = 0;
 
 getMergedChaptersByMangaId:
 SELECT C.*
@@ -98,6 +106,7 @@ LEFT JOIN excluded_scanlators ES
 ON M.merge_id = ES.manga_id
 AND C.scanlator = ES.scanlator
 WHERE M.merge_id = :mangaId
+AND C.deleted = 0
 AND (
     :applyScanlatorFilter = 0
     OR ES.scanlator IS NULL
@@ -109,7 +118,8 @@ FROM (
     SELECT manga_id FROM merged WHERE merge_id = ?
 ) AS M
 JOIN chapters
-ON chapters.manga_id = M.manga_id;
+ON chapters.manga_id = M.manga_id
+WHERE chapters.deleted = 0;
 
 removeChaptersWithIds:
 DELETE FROM chapters
@@ -121,8 +131,8 @@ SET is_syncing = 0
 WHERE is_syncing = 1;
 
 insert:
-INSERT INTO chapters(manga_id, url, name, scanlator, read, bookmark, last_page_read, chapter_number, source_order, date_fetch, date_upload, last_modified_at, version, is_syncing)
-VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, 0, :version, 0);
+INSERT INTO chapters(manga_id, url, name, scanlator, read, bookmark, last_page_read, chapter_number, source_order, date_fetch, date_upload, last_modified_at, version, is_syncing, deleted)
+VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, 0, :version, 0, 0);
 
 update:
 UPDATE chapters
@@ -138,8 +148,16 @@ SET manga_id = coalesce(:mangaId, manga_id),
     date_fetch = coalesce(:dateFetch, date_fetch),
     date_upload = coalesce(:dateUpload, date_upload),
     version = coalesce(:version, version),
-    is_syncing = coalesce(:isSyncing, is_syncing)
+    is_syncing = coalesce(:isSyncing, is_syncing),
+    deleted = coalesce(:deleted, deleted)
 WHERE _id = :chapterId;
+
+-- removed getChaptersByMangaIdIncludeDeleted: merged into getChaptersByMangaId with :includeDeleted flag
+
+softDeleteChaptersWithIds:
+UPDATE chapters
+SET deleted = 1
+WHERE _id IN :chapterIds;
 
 selectLastInsertedRowId:
 SELECT last_insert_rowid();

--- a/data/src/main/sqldelight/tachiyomi/migrations/44.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/44.sqm
@@ -1,0 +1,217 @@
+-- Allow for soft deletions of chapters
+-- This is necessary to make sure that synchronizing to SyncYomi/Google Drive does not re-add deleted chapters
+-- after they have been deleted on the device and propagates the deletion to other devices.
+ALTER TABLE chapters ADD COLUMN deleted INTEGER AS Boolean NOT NULL DEFAULT 0;
+
+-- Update views to preserve soft deletions (deleted = 0)
+DROP VIEW IF EXISTS libraryView;
+
+CREATE VIEW libraryView AS
+SELECT
+    M.*,
+    coalesce(C.total, 0) AS totalCount,
+    coalesce(C.readCount, 0) AS readCount,
+    coalesce(C.latestUpload, 0) AS latestUpload,
+    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
+    coalesce(C.lastRead, 0) AS lastRead,
+    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
+    coalesce(MC.categories, '0') AS categories
+FROM mangas M
+LEFT JOIN (
+    SELECT
+        chapters.manga_id,
+        count(*) AS total,
+        sum(read) AS readCount,
+        coalesce(max(chapters.date_upload), 0) AS latestUpload,
+        coalesce(max(history.last_read), 0) AS lastRead,
+        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
+        sum(chapters.bookmark) AS bookmarkCount,
+        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        excluded_scanlators.scanlator AS ex_scanlator
+    FROM chapters
+    LEFT JOIN excluded_scanlators
+    ON chapters.manga_id = excluded_scanlators.manga_id
+    AND chapters.scanlator = excluded_scanlators.scanlator
+    LEFT JOIN history
+    ON chapters._id = history.chapter_id
+    WHERE ex_scanlator IS NULL
+    AND chapters.deleted = 0
+    GROUP BY chapters.manga_id
+) AS C
+ON M._id = C.manga_id
+LEFT JOIN (
+    SELECT manga_id, group_concat(category_id) AS categories
+    FROM mangas_categories
+    GROUP BY manga_id
+) AS MC
+ON MC.manga_id = M._id
+WHERE M.source <> 6969
+UNION
+SELECT
+    M.*,
+    coalesce(C.total, 0) AS totalCount,
+    coalesce(C.readCount, 0) AS readCount,
+    coalesce(C.latestUpload, 0) AS latestUpload,
+    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
+    coalesce(C.lastRead, 0) AS lastRead,
+    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
+    coalesce(MC.categories, '0') AS categories
+FROM mangas M
+LEFT JOIN (
+    SELECT merged.manga_id,merged.merge_id
+    FROM merged
+    GROUP BY merged.merge_id
+) AS ME
+ON ME.merge_id = M._id
+LEFT JOIN(
+    SELECT
+        ME.merge_id,
+        count(*) AS total,
+        sum(read) AS readCount,
+        coalesce(max(chapters.date_upload), 0) AS latestUpload,
+        coalesce(max(history.last_read), 0) AS lastRead,
+        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
+        sum(chapters.bookmark) AS bookmarkCount,
+        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        excluded_scanlators.scanlator AS ex_scanlator
+    FROM chapters
+    LEFT JOIN excluded_scanlators
+    ON chapters.manga_id = excluded_scanlators.manga_id
+    AND chapters.scanlator = excluded_scanlators.scanlator
+    LEFT JOIN history
+    ON chapters._id = history.chapter_id
+    LEFT JOIN merged ME
+    ON ME.manga_id = chapters.manga_id
+    WHERE ex_scanlator IS NULL
+    AND chapters.deleted = 0
+    GROUP BY ME.merge_id
+) AS C
+ON M._id = C.merge_id
+LEFT JOIN (
+    SELECT manga_id, group_concat(category_id) AS categories
+    FROM mangas_categories
+    GROUP BY manga_id
+) AS MC
+ON MC.manga_id = M._id
+WHERE M.source = 6969;
+
+DROP VIEW IF EXISTS historyView;
+
+CREATE VIEW historyView AS
+SELECT
+    history._id AS id,
+    mangas._id AS mangaId,
+    chapters._id AS chapterId,
+    mangas.title,
+    mangas.thumbnail_url AS thumbnailUrl,
+    mangas.source,
+    mangas.favorite,
+    mangas.cover_last_modified,
+    chapters.chapter_number AS chapterNumber,
+    mangas.chapter_flags AS chapterFlags,
+    chapters.read AS read,
+    chapters.last_page_read AS lastPageRead,
+    coalesce(C.total, 0) AS totalCount,
+    coalesce(C.readCount, 0) AS readCount,
+    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(C.bookmarkReadCount, 0) AS bookmarkReadCount,
+    history.last_read AS readAt,
+    history.time_read AS readDuration,
+    max_last_read.last_read AS maxReadAt,
+    max_last_read.chapter_id AS maxReadAtChapterId
+FROM mangas
+JOIN chapters
+ON mangas._id = chapters.manga_id
+JOIN history
+ON chapters._id = history.chapter_id
+JOIN (
+    SELECT chapters.manga_id,chapters._id AS chapter_id, MAX(history.last_read) AS last_read
+    FROM chapters JOIN history
+    ON chapters._id = history.chapter_id
+    WHERE chapters.deleted = 0
+    GROUP BY chapters.manga_id
+) AS max_last_read
+ON chapters.manga_id = max_last_read.manga_id
+LEFT JOIN(
+    SELECT
+        chapters.manga_id,
+        count(*) AS total,
+        sum(read) AS readCount,
+        sum(bookmark) AS bookmarkCount,
+        sum(CASE WHEN bookmark = 1 AND read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        excluded_scanlators.scanlator AS ex_scanlator
+    FROM chapters
+    LEFT JOIN excluded_scanlators
+    ON chapters.manga_id = excluded_scanlators.manga_id
+    AND chapters.scanlator = excluded_scanlators.scanlator
+    WHERE ex_scanlator IS NULL
+    AND chapters.deleted = 0
+    GROUP BY chapters.manga_id
+) AS C
+ON mangas._id = C.manga_id
+WHERE chapters.deleted = 0;
+
+DROP VIEW IF EXISTS updatesView;
+
+CREATE VIEW updatesView AS
+SELECT
+    mangas._id AS mangaId,
+    mangas.title AS mangaTitle,
+    chapters._id AS chapterId,
+    chapters.name AS chapterName,
+    chapters.scanlator,
+    chapters.url AS chapterUrl,
+    chapters.read,
+    chapters.bookmark,
+    chapters.last_page_read,
+    mangas.source,
+    mangas.favorite,
+    mangas.thumbnail_url AS thumbnailUrl,
+    mangas.cover_last_modified AS coverLastModified,
+    chapters.date_upload AS dateUpload,
+    chapters.date_fetch AS datefetch
+FROM mangas JOIN chapters
+ON mangas._id = chapters.manga_id
+LEFT JOIN excluded_scanlators
+ON mangas._id = excluded_scanlators.manga_id
+AND chapters.scanlator = excluded_scanlators.scanlator
+WHERE favorite = 1 AND source <> 6969
+AND excluded_scanlators.scanlator IS NULL
+AND chapters.deleted = 0
+AND date_fetch > date_added
+UNION
+SELECT
+    mangas._id AS mangaId,
+    mangas.title AS mangaTitle,
+    chapters._id AS chapterId,
+    chapters.name AS chapterName,
+    chapters.scanlator,
+    chapters.url AS chapterUrl,
+    chapters.read,
+    chapters.bookmark,
+    chapters.last_page_read,
+    mangas.source,
+    mangas.favorite,
+    mangas.thumbnail_url AS thumbnailUrl,
+    mangas.cover_last_modified AS coverLastModified,
+    chapters.date_upload AS dateUpload,
+    chapters.date_fetch AS datefetch
+FROM mangas
+LEFT JOIN (
+    SELECT merged.manga_id,merged.merge_id
+    FROM merged
+    GROUP BY merged.merge_id
+) AS ME
+ON ME.merge_id = mangas._id
+JOIN chapters
+ON ME.manga_id = chapters.manga_id
+LEFT JOIN excluded_scanlators
+ON mangas._id = excluded_scanlators.manga_id
+AND chapters.scanlator = excluded_scanlators.scanlator
+WHERE favorite = 1 AND source = 6969
+AND excluded_scanlators.scanlator IS NULL
+AND chapters.deleted = 0
+AND date_fetch > date_added
+ORDER BY datefetch DESC;

--- a/data/src/main/sqldelight/tachiyomi/view/historyView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/historyView.sq
@@ -22,9 +22,11 @@ JOIN (
     SELECT chapters.manga_id,chapters._id AS chapter_id, MAX(history.last_read) AS last_read
     FROM chapters JOIN history
     ON chapters._id = history.chapter_id
+    WHERE chapters.deleted = 0
     GROUP BY chapters.manga_id
 ) AS max_last_read
-ON chapters.manga_id = max_last_read.manga_id;
+ON chapters.manga_id = max_last_read.manga_id
+WHERE chapters.deleted = 0;
 
 history:
 SELECT

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -24,7 +24,7 @@ LEFT JOIN (
     AND chapters.scanlator = excluded_scanlators.scanlator
     LEFT JOIN history
     ON chapters._id = history.chapter_id
-    WHERE excluded_scanlators.scanlator IS NULL
+    WHERE excluded_scanlators.scanlator IS NULL AND chapters.deleted = 0
     GROUP BY chapters.manga_id
 ) AS C
 ON M._id = C.manga_id

--- a/data/src/main/sqldelight/tachiyomi/view/updatesView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/updatesView.sq
@@ -17,7 +17,7 @@ SELECT
     chapters.date_fetch AS datefetch
 FROM mangas JOIN chapters
 ON mangas._id = chapters.manga_id
-WHERE favorite = 1
+WHERE favorite = 1 AND chapters.deleted = 0
 AND date_fetch > date_added
 ORDER BY date_fetch DESC;
 

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapter.kt
@@ -18,9 +18,9 @@ class GetChapter(
         }
     }
 
-    suspend fun await(url: String, mangaId: Long): Chapter? {
+    suspend fun await(url: String, mangaId: Long, includeDeleted: Boolean = false): Chapter? {
         return try {
-            chapterRepository.getChapterByUrlAndMangaId(url, mangaId)
+            chapterRepository.getChapterByUrlAndMangaId(url, mangaId, includeDeleted)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             null

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChapterByUrlAndMangaId.kt
@@ -7,9 +7,9 @@ class GetChapterByUrlAndMangaId(
     private val chapterRepository: ChapterRepository,
 ) {
 
-    suspend fun await(url: String, sourceId: Long): Chapter? {
+    suspend fun await(url: String, sourceId: Long, includeDeleted: Boolean = false): Chapter? {
         return try {
-            chapterRepository.getChapterByUrlAndMangaId(url, sourceId)
+            chapterRepository.getChapterByUrlAndMangaId(url, sourceId, includeDeleted)
         } catch (e: Exception) {
             null
         }

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
@@ -9,12 +9,12 @@ class GetChaptersByMangaId(
     private val chapterRepository: ChapterRepository,
 ) {
 
-    suspend fun await(mangaId: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {
+    suspend fun await(mangaId: Long, applyScanlatorFilter: Boolean = false, includeDeleted: Boolean = false): List<Chapter> {
         return try {
             chapterRepository.getChapterByMangaId(
                 mangaId,
                 applyScanlatorFilter,
-                includeDeleted = false,
+                includeDeleted,
             )
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
@@ -11,7 +11,11 @@ class GetChaptersByMangaId(
 
     suspend fun await(mangaId: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {
         return try {
-            chapterRepository.getChapterByMangaId(mangaId, applyScanlatorFilter, includeDeleted = false)
+            chapterRepository.getChapterByMangaId(
+                mangaId,
+                applyScanlatorFilter,
+                includeDeleted = false,
+            )
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             emptyList()

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetChaptersByMangaId.kt
@@ -11,7 +11,7 @@ class GetChaptersByMangaId(
 
     suspend fun await(mangaId: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {
         return try {
-            chapterRepository.getChapterByMangaId(mangaId, applyScanlatorFilter)
+            chapterRepository.getChapterByMangaId(mangaId, applyScanlatorFilter, includeDeleted = false)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             emptyList()

--- a/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
@@ -15,6 +15,7 @@ data class Chapter(
     val scanlator: String?,
     val lastModifiedAt: Long,
     val version: Long,
+    val deleted: Boolean = false,
 ) {
     val isRecognizedNumber: Boolean
         get() = chapterNumber >= 0f
@@ -45,6 +46,7 @@ data class Chapter(
             scanlator = null,
             lastModifiedAt = 0,
             version = 1,
+            deleted = false,
         )
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/chapter/model/ChapterUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/model/ChapterUpdate.kt
@@ -14,6 +14,7 @@ data class ChapterUpdate(
     val chapterNumber: Double? = null,
     val scanlator: String? = null,
     val version: Long? = null,
+    val deleted: Boolean? = null,
 )
 
 fun Chapter.toChapterUpdate(): ChapterUpdate {
@@ -31,5 +32,6 @@ fun Chapter.toChapterUpdate(): ChapterUpdate {
         chapterNumber,
         scanlator,
         version,
+        deleted,
     )
 }

--- a/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
@@ -36,7 +36,7 @@ interface ChapterRepository {
         includeDeleted: Boolean = false,
     ): Flow<List<Chapter>>
 
-    suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long): Chapter?
+    suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long, includeDeleted: Boolean = false): Chapter?
 
     // SY -->
     suspend fun getChapterByUrl(url: String): List<Chapter>

--- a/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
@@ -14,7 +14,9 @@ interface ChapterRepository {
 
     suspend fun removeChaptersWithIds(chapterIds: List<Long>)
 
-    suspend fun getChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean = false): List<Chapter>
+    suspend fun softDeleteChaptersWithIds(chapterIds: List<Long>)
+
+    suspend fun getChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean = false, includeDeleted: Boolean = false): List<Chapter>
 
     suspend fun getScanlatorsByMangaId(mangaId: Long): List<String>
 
@@ -24,7 +26,7 @@ interface ChapterRepository {
 
     suspend fun getChapterById(id: Long): Chapter?
 
-    suspend fun getChapterByMangaIdAsFlow(mangaId: Long, applyScanlatorFilter: Boolean = false): Flow<List<Chapter>>
+    suspend fun getChapterByMangaIdAsFlow(mangaId: Long, applyScanlatorFilter: Boolean = false, includeDeleted: Boolean = false): Flow<List<Chapter>>
 
     suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long): Chapter?
 

--- a/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/repository/ChapterRepository.kt
@@ -16,7 +16,11 @@ interface ChapterRepository {
 
     suspend fun softDeleteChaptersWithIds(chapterIds: List<Long>)
 
-    suspend fun getChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean = false, includeDeleted: Boolean = false): List<Chapter>
+    suspend fun getChapterByMangaId(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean = false,
+        includeDeleted: Boolean = false,
+    ): List<Chapter>
 
     suspend fun getScanlatorsByMangaId(mangaId: Long): List<String>
 
@@ -26,14 +30,21 @@ interface ChapterRepository {
 
     suspend fun getChapterById(id: Long): Chapter?
 
-    suspend fun getChapterByMangaIdAsFlow(mangaId: Long, applyScanlatorFilter: Boolean = false, includeDeleted: Boolean = false): Flow<List<Chapter>>
+    suspend fun getChapterByMangaIdAsFlow(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean = false,
+        includeDeleted: Boolean = false,
+    ): Flow<List<Chapter>>
 
     suspend fun getChapterByUrlAndMangaId(url: String, mangaId: Long): Chapter?
 
     // SY -->
     suspend fun getChapterByUrl(url: String): List<Chapter>
 
-    suspend fun getMergedChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean = false): List<Chapter>
+    suspend fun getMergedChapterByMangaId(
+        mangaId: Long,
+        applyScanlatorFilter: Boolean = false,
+    ): List<Chapter>
 
     suspend fun getMergedChapterByMangaIdAsFlow(
         mangaId: Long,

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
@@ -12,13 +12,18 @@ class GetMangaWithChapters(
     private val chapterRepository: ChapterRepository,
 ) {
 
-    suspend fun subscribe(id: Long, applyScanlatorFilter: Boolean = false): Flow<Pair<Manga, List<Chapter>>> {
+    suspend fun subscribe(
+        id: Long,
+        applyScanlatorFilter: Boolean = false,
+    ): Flow<Pair<Manga, List<Chapter>>> {
         return combine(
             mangaRepository.getMangaByIdAsFlow(id),
-            chapterRepository.getChapterByMangaIdAsFlow(id, applyScanlatorFilter, includeDeleted = false),
-        ) { manga, chapters ->
-            Pair(manga, chapters)
-        }
+            chapterRepository.getChapterByMangaIdAsFlow(
+                id,
+                applyScanlatorFilter,
+                includeDeleted = false,
+            ),
+        ) { manga, chapters -> Pair(manga, chapters) }
     }
 
     suspend fun awaitManga(id: Long): Manga {
@@ -26,6 +31,10 @@ class GetMangaWithChapters(
     }
 
     suspend fun awaitChapters(id: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {
-        return chapterRepository.getChapterByMangaId(id, applyScanlatorFilter, includeDeleted = false)
+        return chapterRepository.getChapterByMangaId(
+            id,
+            applyScanlatorFilter,
+            includeDeleted = false,
+        )
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
@@ -15,7 +15,7 @@ class GetMangaWithChapters(
     suspend fun subscribe(id: Long, applyScanlatorFilter: Boolean = false): Flow<Pair<Manga, List<Chapter>>> {
         return combine(
             mangaRepository.getMangaByIdAsFlow(id),
-            chapterRepository.getChapterByMangaIdAsFlow(id, applyScanlatorFilter),
+            chapterRepository.getChapterByMangaIdAsFlow(id, applyScanlatorFilter, includeDeleted = false),
         ) { manga, chapters ->
             Pair(manga, chapters)
         }
@@ -26,6 +26,6 @@ class GetMangaWithChapters(
     }
 
     suspend fun awaitChapters(id: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {
-        return chapterRepository.getChapterByMangaId(id, applyScanlatorFilter)
+        return chapterRepository.getChapterByMangaId(id, applyScanlatorFilter, includeDeleted = false)
     }
 }


### PR DESCRIPTION
Solves the issue of "ghost chapters" reappearing after sync.

On many sources, chapters sometimes get replaced with other variants or just outright deleted. Currently, when that happens, the old chapters will be restored from the synchronization. This solves the issue by soft deleting removed chapters.

This way, when synchronizing, removed chapters will not be restored again and again since we aren't "forgetting" that they were purposefully removed. Otherwise it will think that, while comparing with remote, new chapters have been added even though those were just removed locally. 

This is especially critical when _some unnamed sources_ (you know who you are!) decide that all chapters are now different (except they aren't), creating new entities leading to duplicates everywhere.

---

I orignally wrote this for a [PR I submitted to komikku](https://github.com/komikku-app/komikku/pull/1161) and had that reviewed by @kaiserbh, but then forgot about also writing a PR for that here. Sorry about that :sweat_smile: 
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
