### PR TITLE
feat: Add sync events to SyncYomi

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
@@ -54,7 +54,7 @@ class SyncYomiSyncService(
         SYNC_SUCCESS,
         SYNC_FAILED,
         SYNC_ERROR,
-        SYNC_CANCELLED
+        SYNC_CANCELLED,
     }
 
     override suspend fun doSync(syncData: SyncData): Backup? {


### PR DESCRIPTION
Now it will send the events back to `SyncYomi` server and then forward those to the notification services that are enabled, such as discord, telegram, and etc.
