### PR TITLE
Fix: Resolve infinite sync loops causing gigantic unnecessary restorations

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -122,13 +122,17 @@ class MangaRestorer(
         return this.copy(
             favorite = this.favorite || newer.favorite,
             // SY -->
-            ogAuthor = newer.author,
-            ogArtist = newer.artist,
-            ogDescription = newer.description,
-            ogGenre = newer.genre,
-            ogThumbnailUrl = newer.thumbnailUrl,
-            ogStatus = newer.status,
+            ogTitle = newer.ogTitle,
+            ogAuthor = newer.ogAuthor,
+            ogArtist = newer.ogArtist,
+            ogDescription = newer.ogDescription,
+            ogGenre = newer.ogGenre,
+            ogThumbnailUrl = newer.ogThumbnailUrl,
+            ogStatus = newer.ogStatus,
             // SY <--
+            chapterFlags = newer.chapterFlags,
+            viewerFlags = newer.viewerFlags,
+            updateStrategy = newer.updateStrategy,
             initialized = this.initialized || newer.initialized,
             version = newer.version,
         )
@@ -186,7 +190,13 @@ class MangaRestorer(
 
                 when {
                     dbChapter == null -> chapter // New chapter
-                    chapter.forComparison() == dbChapter.forComparison() -> null // Same state; skip
+                    chapter.forComparison() == dbChapter.forComparison() -> {
+                        if (isSync && chapter.version != dbChapter.version) {
+                            chapter.copy(id = dbChapter.id)
+                        } else {
+                            null // Same state; skip
+                        }
+                    }
                     else -> updateChapterBasedOnSyncState(chapter, dbChapter)
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -6,6 +6,7 @@ import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.tachiyomi.data.backup.create.BackupCreator
 import eu.kanade.tachiyomi.data.backup.create.BackupOptions
 import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupChapter
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
@@ -295,13 +296,13 @@ class SyncManager(
         val elapsedTimeMillis = measureTimeMillis {
             val databaseManga = getAllMangaFromDB()
             val localMangaMap = databaseManga.associateBy {
-                Triple(it.source, it.url, it.title)
+                Pair(it.source, it.url)
             }
 
             logcat(LogPriority.DEBUG, logTag) { "Starting to filter favorites and non-favorites from backup data." }
 
             backup.backupManga.forEach { remoteManga ->
-                val compositeKey = Triple(remoteManga.source, remoteManga.url, remoteManga.title)
+                val compositeKey = Pair(remoteManga.source, remoteManga.url)
                 val localManga = localMangaMap[compositeKey]
                 when {
                     // Checks if the manga is in favorites and needs updating or adding
@@ -339,10 +340,10 @@ class SyncManager(
     private suspend fun updateNonFavorites(nonFavorites: List<BackupManga>) {
         val localMangaList = getAllMangaFromDB()
 
-        val localMangaMap = localMangaList.associateBy { Triple(it.source, it.url, it.title) }
+        val localMangaMap = localMangaList.associateBy { Pair(it.source, it.url) }
 
         nonFavorites.forEach { nonFavorite ->
-            val key = Triple(nonFavorite.source, nonFavorite.url, nonFavorite.title)
+            val key = Pair(nonFavorite.source, nonFavorite.url)
             localMangaMap[key]?.let { localManga ->
                 if (localManga.favorite != nonFavorite.favorite) {
                     val updatedManga = localManga.copy(favorite = nonFavorite.favorite)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -109,7 +109,7 @@ abstract class SyncService(
         }
 
         fun mangaCompositeKey(manga: BackupManga): String {
-            return "${manga.source}|${manga.url}|${manga.title.lowercase().trim()}|${manga.author?.lowercase()?.trim()}"
+            return "${manga.source}|${manga.url}"
         }
 
         // Create maps using composite keys
@@ -201,7 +201,7 @@ abstract class SyncService(
         val logTag = "MergeChapters"
 
         fun chapterCompositeKey(chapter: BackupChapter): String {
-            return "${chapter.url}|${chapter.name}|${chapter.chapterNumber}"
+            return chapter.url
         }
 
         val localChapterMap = localChapters.associateBy { chapterCompositeKey(it) }


### PR DESCRIPTION
Currently, the synchronization functionality suffers from a severe "ping-pong" loop where devices continuously trigger full restorations of hundreds or thousands of mangas unnecessarily. This causes massive, long-running sync operations even when no actual changes have been made by the user.

<img width="1440" height="252" alt="Screenshot showing the concluding notification after a restoration with 21:40 minutes." src="https://github.com/user-attachments/assets/655854fc-3be5-407a-aab6-e6c306da7802" />

The above screenshot shows why I created this PR, with a synchronization of literally nothing taking 21 minutes and 40 seconds.

This runaway restoration loop is caused by a few specific oversights in how the sync system compares and updates local vs. remote states:

## The problems

1. **Chapter Version Skipping (`MangaRestorer.kt`):** When a remote chapter is downloaded that has an identical read/bookmark state to the local database but a higher `version`, the restorer optimized the process by completely skipping the chapter. Because it was skipped, the local chapter's `version` was never updated to match the remote. On the very next sync, `SyncManager.areChaptersDifferent` detected the mismatched versions and falsely flagged the entire manga as modified, triggering another massive restoration.
2. **Missing Title Mapping (`MangaRestorer.kt`):** The `Manga.copyFrom` method was missing several critical fields, most notably `ogTitle` and the sync state flags (`chapterFlags`, `viewerFlags`, `updateStrategy`). When a remote manga was restored, its title was never saved to the local database. 
3. **Volatile Lookup Keys (`SyncManager.kt` & `SyncService.kt`):** The sync logic used display metadata like `title`, `author`, and chapter `name` in its lookup maps. Because the local database's `ogTitle` was never updating (due to the bug above), `SyncManager` would look for the old title in memory, fail to find the remote's new title, assume it was a brand-new manga, and trigger a full restoration. The database would correctly deduplicate it upon insertion, but the loop would repeat indefinitely.

## Bug-Flow
```mermaid
sequenceDiagram
    participant A as Device A
    participant S as Sync Server
    participant B as Device B

    Note over A, B: Both devices initially up-to-date
    A->>A: Sets 1 chapter to read
    A->>S: Synchronizes changes

    B->>S: Starts synchronization
    S-->>B: Downloads backup
    Note over B: Bug triggered: Mismatched keys and skipped versions
    B->>B: Restores hundreds/thousands of unaffected mangas
    B->>S: Uploads "merged" state with mismatched versions

    Note over A: User makes NO changes
    A->>S: Synchronizes again
    S-->>A: Downloads backup from B
    Note over A: Bug triggered: Mismatched keys and skipped versions
    A->>A: Restores hundreds/thousands of unaffected mangas
    A->>S: Uploads "merged" state again

    Note over A, B: The Ping-Pong Loop continues indefinitely...
```

## The Solution
This PR implements the minimal structural fixes required to permanently terminate these sync loops:

* **Chapter Version Alignment:** Updated `MangaRestorer.restoreChapters` to explicitly adopt the remote chapter's `version` (via a lightweight `.copy(id = dbChapter.id)`) even if the content state is identical, permanently breaking the version mismatch loop.
* **Stable Identifiers:** Changed `mangaCompositeKey` in `SyncService` and the `localMangaMap` in `SyncManager` to strictly use `Pair(source, url)`. Chapter keys were reverted to `url`. This guarantees mangas and chapters are matched purely by their immutable backend IDs, preventing volatile display names from tricking the app into restoring them.
* **Correct Database Mapping:** Fixed `Manga.copyFrom` in `MangaRestorer` to correctly map to `ogTitle`, `ogAuthor`, etc. instead of the frontend override fields, and included the missing `chapterFlags`, `viewerFlags`, and `updateStrategy` mappings so the database properly adopts the remote sync state.