### PR TITLE
Implement Data Saver for manga covers

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -93,19 +93,6 @@ class SourcePreferences(
 
     val dataSaverCovers: Preference<Boolean> = preferenceStore.getBoolean("data_saver_covers", false)
 
-    fun getCoverDataSaverKey(sourceId: Long?): String {
-        val dataSaver = dataSaver.get()
-        val dataSaverCovers = dataSaverCovers.get()
-        val excludedSources = dataSaverExcludedSources.get()
-        if (dataSaver == DataSaver.NONE || !dataSaverCovers || sourceId?.toString() in excludedSources) {
-            return ""
-        }
-        val quality = dataSaverImageQuality.get()
-        val format = dataSaverImageFormatJpeg.get()
-        val colorBW = dataSaverColorBW.get()
-        return "$dataSaver-$quality-$format-$colorBW"
-    }
-
     enum class DataSaver {
         NONE,
         BANDWIDTH_HERO,

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -91,6 +91,21 @@ class SourcePreferences(
 
     val dataSaverDownloader: Preference<Boolean> = preferenceStore.getBoolean("data_saver_downloader", true)
 
+    val dataSaverCovers: Preference<Boolean> = preferenceStore.getBoolean("data_saver_covers", false)
+
+    fun getCoverDataSaverKey(sourceId: Long?): String {
+        val dataSaver = dataSaver.get()
+        val dataSaverCovers = dataSaverCovers.get()
+        val excludedSources = dataSaverExcludedSources.get()
+        if (dataSaver == DataSaver.NONE || !dataSaverCovers || sourceId?.toString() in excludedSources) {
+            return ""
+        }
+        val quality = dataSaverImageQuality.get()
+        val format = dataSaverImageFormatJpeg.get()
+        val colorBW = dataSaverColorBW.get()
+        return "$dataSaver-$quality-$format-$colorBW"
+    }
+
     enum class DataSaver {
         NONE,
         BANDWIDTH_HERO,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -684,6 +684,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     enabled = dataSaver != DataSaver.NONE,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
+                    preference = sourcePreferences.dataSaverCovers,
+                    title = stringResource(SYMR.strings.data_saver_covers),
+                    enabled = dataSaver != DataSaver.NONE,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
                     preference = sourcePreferences.dataSaverIgnoreJpeg,
                     title = stringResource(SYMR.strings.data_saver_ignore_jpeg),
                     enabled = dataSaver != DataSaver.NONE,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -12,10 +12,12 @@ import coil3.fetch.SourceFetchResult
 import coil3.getOrDefault
 import coil3.request.Options
 import com.hippo.unifile.UniFile
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher.Companion.USE_CUSTOM_COVER_KEY
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.source.online.HttpSource
+import exh.util.DataSaver
 import logcat.LogPriority
 import okhttp3.CacheControl
 import okhttp3.Call
@@ -56,6 +58,8 @@ class MangaCoverFetcher(
     private val callFactoryLazy: Lazy<Call.Factory>,
     private val imageLoader: ImageLoader,
 ) : Fetcher {
+
+    private val sourcePreferences: SourcePreferences by injectLazy()
 
     private val diskCacheKey: String
         get() = diskCacheKeyLazy.value
@@ -181,9 +185,15 @@ class MangaCoverFetcher(
 
     private fun newRequest(): Request {
         val request = Request.Builder().apply {
-            url(url!!)
+            val source = sourceLazy.value
+            val dataSaver = if (source != null && sourcePreferences.dataSaverCovers.get()) {
+                DataSaver(source, sourcePreferences)
+            } else {
+                DataSaver.NoOp
+            }
+            url(dataSaver.compress(url!!))
 
-            val sourceHeaders = sourceLazy.value?.headers
+            val sourceHeaders = source?.headers
             if (sourceHeaders != null) {
                 headers(sourceHeaders)
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -17,7 +17,7 @@ class MangaKeyer(
         return if (data.hasCustomCover()) {
             "${data.id};${data.coverLastModified}"
         } else {
-            "${data.thumbnailUrl};${data.coverLastModified};${sourcePreferences.getCoverDataSaverKey(data.source)}"
+            "${data.thumbnailUrl};${data.coverLastModified};${getCoverDataSaverKey(sourcePreferences, data.source)}"
         }
     }
 }
@@ -30,7 +30,20 @@ class MangaCoverKeyer(
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
-            "${data.url};${data.lastModified};${sourcePreferences.getCoverDataSaverKey(data.sourceId)}"
+            "${data.url};${data.lastModified};${getCoverDataSaverKey(sourcePreferences, data.sourceId)}"
         }
     }
+}
+
+private fun getCoverDataSaverKey(sourcePreferences: SourcePreferences, sourceId: Long?): String {
+    val dataSaver = sourcePreferences.dataSaver.get()
+    val dataSaverCovers = sourcePreferences.dataSaverCovers.get()
+    val excludedSources = sourcePreferences.dataSaverExcludedSources.get()
+    if (dataSaver == SourcePreferences.DataSaver.NONE || !dataSaverCovers || sourceId?.toString() in excludedSources) {
+        return ""
+    }
+    val quality = sourcePreferences.dataSaverImageQuality.get()
+    val format = sourcePreferences.dataSaverImageFormatJpeg.get()
+    val colorBW = sourcePreferences.dataSaverColorBW.get()
+    return "$dataSaver-$quality-$format-$colorBW"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -3,30 +3,34 @@ package eu.kanade.tachiyomi.data.coil
 import coil3.key.Keyer
 import coil3.request.Options
 import eu.kanade.domain.manga.model.hasCustomCover
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import tachiyomi.domain.manga.model.MangaCover
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import tachiyomi.domain.manga.model.Manga as DomainManga
 
-class MangaKeyer : Keyer<DomainManga> {
+class MangaKeyer(
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+) : Keyer<DomainManga> {
     override fun key(data: DomainManga, options: Options): String {
         return if (data.hasCustomCover()) {
             "${data.id};${data.coverLastModified}"
         } else {
-            "${data.thumbnailUrl};${data.coverLastModified}"
+            "${data.thumbnailUrl};${data.coverLastModified};${sourcePreferences.getCoverDataSaverKey(data.source)}"
         }
     }
 }
 
 class MangaCoverKeyer(
     private val coverCache: CoverCache = Injekt.get(),
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<MangaCover> {
     override fun key(data: MangaCover, options: Options): String {
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
-            "${data.url};${data.lastModified}"
+            "${data.url};${data.lastModified};${sourcePreferences.getCoverDataSaverKey(data.sourceId)}"
         }
     }
 }

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -140,6 +140,7 @@
     <string name="data_saver">Data Saver</string>
     <string name="data_saver_summary">Compress images before downloading or loading in reader</string>
     <string name="data_saver_downloader">Use data saver in the downloader</string>
+    <string name="data_saver_covers">Use data saver for covers</string>
     <string name="data_saver_ignore_jpeg">Ignore Jpeg Images</string>
     <string name="data_saver_ignore_gif">Ignore Gif Animations</string>
     <string name="data_saver_image_quality">Image Quality</string>


### PR DESCRIPTION
- Added `dataSaverCovers` preference to `SourcePreferences`.
- Added `getCoverDataSaverKey` helper in `SourcePreferences` for consistent cache invalidation.
- Added "Use data saver for covers" toggle in `SettingsAdvancedScreen`.
- Modified `MangaCoverFetcher` to apply compression to cover URLs when enabled, respecting source exclusions.
- Updated `MangaKeyer` and `MangaCoverKeyer` to include Data Saver settings in Coil cache keys.
- Added string resource in English (base).

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
