### PR TITLE
fix: use async SQLDelight API in MoveSortingModeSettingsMigration

### DIFF
--- a/app/src/main/java/mihon/core/migration/migrations/MoveSortingModeSettingsMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/MoveSortingModeSettingsMigration.kt
@@ -3,6 +3,7 @@ package mihon.core.migration.migrations
 import android.app.Application
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import app.cash.sqldelight.async.coroutines.awaitAsList
 import mihon.core.migration.Migration
 import mihon.core.migration.MigrationContext
 import tachiyomi.core.common.util.lang.withIOContext
@@ -32,7 +33,7 @@ class MoveSortingModeSettingsMigration : Migration {
             putString(libraryPreferences.sortingMode.key(), newSortingMode)
         }
         database.transaction {
-            database.categoriesQueries.getCategories(CategoryMapper::mapCategory).executeAsList()
+            database.categoriesQueries.getCategories(CategoryMapper::mapCategory).awaitAsList()
                 .filter { (it.flags and 0b00111100L) == 0b00100000L }
                 .forEach {
                     database.categoriesQueries.update(


### PR DESCRIPTION
when opening after updating from an older version of app (database v < 38) the app crashes since it tries to use a synchronous sqldelight function after the async update. you can recreate using below to forcefully set to database v37:

```sh
PKG=eu.kanade.tachiyomi.sy.debug
PREFS=/data/data/$PKG/shared_prefs/${PKG}_preferences.xml
adb shell am force-stop $PKG
# set the stored version code to 37 (below the v38 migration)
adb shell "run-as $PKG sed -i -E 's#(<int name=\"__APP_STATE_eh_last_version_code\" value=\")[0-9-]+#\\137#' $PREFS"
adb shell monkey -p $PKG -c android.intent.category.LAUNCHER 1   # crashes on launch
```
