### PR TITLE
Add option to hide entries in reading history from browsing results

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -12,6 +12,7 @@ import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.GetBrowseMangaFilter
 import eu.kanade.domain.source.interactor.GetEnabledSources
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.interactor.GetLanguagesWithSources
@@ -81,6 +82,7 @@ import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
 import tachiyomi.domain.manga.interactor.GetMangaWithChapters
+import tachiyomi.domain.manga.interactor.GetReadMangaIds
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
 import tachiyomi.domain.manga.interactor.SetMangaChapterFlags
@@ -122,6 +124,7 @@ class DomainModule : InjektModule {
         addFactory { GetMangaWithChapters(get(), get()) }
         addFactory { GetMangaByUrlAndSourceId(get()) }
         addFactory { GetManga(get()) }
+        addFactory { GetReadMangaIds(get()) }
         addFactory { GetNextChapters(get(), get(), get(), get()) }
         addFactory { GetUpcomingManga(get()) }
         addFactory { ResetViewerFlags(get()) }
@@ -133,6 +136,7 @@ class DomainModule : InjektModule {
         addFactory { UpdateManga(get(), get()) }
         addFactory { UpdateMangaNotes(get()) }
         addFactory { SetMangaCategories(get()) }
+        addFactory { GetBrowseMangaFilter(get(), get()) }
         addFactory { GetExcludedScanlators(get()) }
         addFactory { SetExcludedScanlators(get()) }
         addFactory {

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetBrowseMangaFilter.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetBrowseMangaFilter.kt
@@ -1,0 +1,33 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.domain.manga.interactor.GetReadMangaIds
+import tachiyomi.domain.manga.model.Manga
+
+class GetBrowseMangaFilter(
+    private val sourcePreferences: SourcePreferences,
+    private val getReadMangaIds: GetReadMangaIds,
+) {
+
+    suspend operator fun invoke(filterReadItems: Boolean = true): BrowseMangaFilter {
+        val hideReadItems = filterReadItems && sourcePreferences.hideReadItems.get()
+        return BrowseMangaFilter(
+            hideInLibraryItems = sourcePreferences.hideInLibraryItems.get(),
+            readMangaIds = if (hideReadItems) getReadMangaIds.await() else emptySet(),
+        )
+    }
+}
+
+data class BrowseMangaFilter(
+    private val hideInLibraryItems: Boolean,
+    private val readMangaIds: Set<Long>,
+) {
+
+    fun isVisible(manga: Manga): Boolean {
+        return isVisible(manga.id, manga.favorite)
+    }
+
+    internal fun isVisible(mangaId: Long, isFavorite: Boolean): Boolean {
+        return (!hideInLibraryItems || !isFavorite) && mangaId !in readMangaIds
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -50,6 +50,8 @@ class SourcePreferences(
 
     val hideInLibraryItems: Preference<Boolean> = preferenceStore.getBoolean("browse_hide_in_library_items", false)
 
+    val hideReadItems: Preference<Boolean> = preferenceStore.getBoolean("browse_hide_read_items", false)
+
     val extensionRepos: Preference<Set<String>> = preferenceStore.getStringSet("extension_repos", emptySet())
 
     val extensionUpdatesCount: Preference<Int> = preferenceStore.getInt("ext_updates_count", 0)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
@@ -103,6 +103,11 @@ object SettingsBrowseScreen : SearchableSettings {
                         preference = sourcePreferences.hideInLibraryItems,
                         title = stringResource(MR.strings.pref_hide_in_library_items),
                     ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = sourcePreferences.hideReadItems,
+                        title = stringResource(MR.strings.pref_hide_read_items),
+                        subtitle = stringResource(MR.strings.pref_hide_read_items_summary),
+                    ),
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(MR.strings.extensionStores),
                         subtitle = pluralStringResource(MR.plurals.num_repos, reposCount.toInt(), reposCount),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.util.fastAny
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.GetBrowseMangaFilter
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.browse.FeedItemUI
 import eu.kanade.tachiyomi.source.Source
@@ -56,6 +57,7 @@ open class FeedScreenModel(
     val sourcePreferences: SourcePreferences = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val getBrowseMangaFilter: GetBrowseMangaFilter = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val getFeedSavedSearchGlobal: GetFeedSavedSearchGlobal = Injekt.get(),
     private val getSavedSearchGlobalFeed: GetSavedSearchGlobalFeed = Injekt.get(),
@@ -224,6 +226,7 @@ open class FeedScreenModel(
      */
     private fun getFeed(feedSavedSearch: List<FeedItemUI>) {
         screenModelScope.launch {
+            val browseMangaFilter = getBrowseMangaFilter()
             feedSavedSearch.map { itemUI ->
                 async {
                     val page = try {
@@ -248,7 +251,8 @@ open class FeedScreenModel(
 
                     val result = withIOContext {
                         itemUI.copy(
-                            results = networkToLocalManga(page.map { it.toDomainManga(itemUI.source!!.id) }),
+                            results = networkToLocalManga(page.map { it.toDomainManga(itemUI.source!!.id) })
+                                .filter(browseMangaFilter::isVisible),
                         )
                     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreenModel.kt
@@ -17,7 +17,7 @@ class MigrateSearchScreenModel(
     getManga: GetManga = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val sourcePreferences: SourcePreferences = Injekt.get(),
-) : SearchScreenModel() {
+) : SearchScreenModel(filterReadItems = false) {
 
     private val migrationSources by lazy { sourcePreferences.migrationSources.get() }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSourceSearchScreen.kt
@@ -59,7 +59,13 @@ data class MigrateSourceSearchScreen(
         val navigator = LocalNavigator.currentOrThrow
         val scope = rememberCoroutineScope()
 
-        val screenModel = rememberScreenModel { BrowseSourceScreenModel(sourceId, query) }
+        val screenModel = rememberScreenModel {
+            BrowseSourceScreenModel(
+                sourceId = sourceId,
+                listingQuery = query,
+                filterReadItems = false,
+            )
+        }
         val state by screenModel.state.collectAsState()
 
         val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -178,12 +178,12 @@ open class BrowseSourceScreenModel(
     val mangaPagerFlowFlow = state.map { it.listing }
         .distinctUntilChanged()
         .map { listing ->
-            val browseMangaFilter = getBrowseMangaFilter(filterReadItems)
             Pager(PagingConfig(pageSize = 25)) {
                 // SY -->
                 createSourcePagingSource(listing.query ?: "", listing.filters)
                 // SY <--
             }.flow.map { pagingData ->
+                val browseMangaFilter = getBrowseMangaFilter(filterReadItems)
                 pagingData
                     .filter { (manga) -> browseMangaFilter.isVisible(manga) }
                     .map { (manga, metadata) ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -16,6 +16,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.core.preference.asState
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.GetBrowseMangaFilter
 import eu.kanade.domain.source.interactor.GetExhSavedSearch
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.service.SourcePreferences
@@ -84,6 +85,7 @@ open class BrowseSourceScreenModel(
     private val filtersJson: String? = null,
     private val savedSearch: Long? = null,
     // SY <--
+    private val filterReadItems: Boolean = true,
     private val sourceManager: SourceManager = Injekt.get(),
     sourcePreferences: SourcePreferences = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
@@ -94,6 +96,7 @@ open class BrowseSourceScreenModel(
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
+    private val getBrowseMangaFilter: GetBrowseMangaFilter = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
     getIncognitoState: GetIncognitoState = Injekt.get(),
@@ -172,24 +175,25 @@ open class BrowseSourceScreenModel(
     /**
      * Flow of Pager flow tied to [State.listing]
      */
-    private val hideInLibraryItems = sourcePreferences.hideInLibraryItems.get()
     val mangaPagerFlowFlow = state.map { it.listing }
         .distinctUntilChanged()
         .map { listing ->
+            val browseMangaFilter = getBrowseMangaFilter(filterReadItems)
             Pager(PagingConfig(pageSize = 25)) {
                 // SY -->
                 createSourcePagingSource(listing.query ?: "", listing.filters)
                 // SY <--
             }.flow.map { pagingData ->
-                pagingData.map { (manga, metadata) ->
-                    getManga.subscribe(manga.url, manga.source)
-                        .map { it ?: manga }
-                        // SY -->
-                        .combineMetadata(metadata)
-                        // SY <--
-                        .stateIn(ioCoroutineScope)
-                }
-                    .filter { !hideInLibraryItems || !it.value.first.favorite }
+                pagingData
+                    .filter { (manga) -> browseMangaFilter.isVisible(manga) }
+                    .map { (manga, metadata) ->
+                        getManga.subscribe(manga.url, manga.source)
+                            .map { it ?: manga }
+                            // SY -->
+                            .combineMetadata(metadata)
+                            // SY <--
+                            .stateIn(ioCoroutineScope)
+                    }
             }
                 .cachedIn(ioCoroutineScope)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -10,6 +10,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.core.preference.asState
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.GetBrowseMangaFilter
 import eu.kanade.domain.source.interactor.GetExhSavedSearch
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.browse.SourceFeedUI
@@ -58,6 +59,7 @@ open class SourceFeedScreenModel(
     private val sourceManager: SourceManager = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val getBrowseMangaFilter: GetBrowseMangaFilter = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val getFeedSavedSearchBySourceId: GetFeedSavedSearchBySourceId = Injekt.get(),
     private val getSavedSearchBySourceIdFeed: GetSavedSearchBySourceIdFeed = Injekt.get(),
@@ -145,6 +147,7 @@ open class SourceFeedScreenModel(
      */
     private fun getFeed(feedSavedSearch: List<SourceFeedUI>) {
         screenModelScope.launch {
+            val browseMangaFilter = getBrowseMangaFilter()
             feedSavedSearch.map { sourceFeed ->
                 async {
                     val page = try {
@@ -165,6 +168,7 @@ open class SourceFeedScreenModel(
 
                     val titles = withIOContext {
                         networkToLocalManga(page.map { it.toDomainManga(source.id) })
+                            .filter(browseMangaFilter::isVisible)
                     }
 
                     mutableState.update { state ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.produceState
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.interactor.GetBrowseMangaFilter
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.extension.ExtensionManager
@@ -32,11 +33,13 @@ import java.util.concurrent.Executors
 
 abstract class SearchScreenModel(
     initialState: State = State(),
+    private val filterReadItems: Boolean = true,
     sourcePreferences: SourcePreferences = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val extensionManager: ExtensionManager = Injekt.get(),
     private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
+    private val getBrowseMangaFilter: GetBrowseMangaFilter = Injekt.get(),
     private val preferences: SourcePreferences = Injekt.get(),
 ) : StateScreenModel<SearchScreenModel.State>(initialState) {
 
@@ -151,6 +154,7 @@ abstract class SearchScreenModel(
         }
 
         searchJob = ioCoroutineScope.launch {
+            val browseMangaFilter = getBrowseMangaFilter(filterReadItems)
             sources.map { source ->
                 async {
                     if (state.value.items[source] !is SearchItemResult.Loading) {
@@ -166,6 +170,7 @@ abstract class SearchScreenModel(
                             .map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
                             .let { networkToLocalManga(it) }
+                            .filter(browseMangaFilter::isVisible)
 
                         if (isActive) {
                             updateItem(source, SearchItemResult.Success(titles))

--- a/app/src/test/java/eu/kanade/domain/source/interactor/BrowseMangaFilterTest.kt
+++ b/app/src/test/java/eu/kanade/domain/source/interactor/BrowseMangaFilterTest.kt
@@ -1,0 +1,39 @@
+package eu.kanade.domain.source.interactor
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class BrowseMangaFilterTest {
+
+    @Test
+    fun `visible when filters are disabled`() {
+        val filter = BrowseMangaFilter(
+            hideInLibraryItems = false,
+            readMangaIds = emptySet(),
+        )
+
+        filter.isVisible(mangaId = 1, isFavorite = true) shouldBe true
+    }
+
+    @Test
+    fun `hidden when already in library`() {
+        val filter = BrowseMangaFilter(
+            hideInLibraryItems = true,
+            readMangaIds = emptySet(),
+        )
+
+        filter.isVisible(mangaId = 1, isFavorite = true) shouldBe false
+        filter.isVisible(mangaId = 2, isFavorite = false) shouldBe true
+    }
+
+    @Test
+    fun `hidden when reading history exists`() {
+        val filter = BrowseMangaFilter(
+            hideInLibraryItems = false,
+            readMangaIds = setOf(2),
+        )
+
+        filter.isVisible(mangaId = 1, isFavorite = false) shouldBe true
+        filter.isVisible(mangaId = 2, isFavorite = false) shouldBe false
+    }
+}

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -63,6 +63,13 @@ class MangaRepositoryImpl(
             .awaitAsList()
     }
 
+    override suspend fun getReadMangaIds(): Set<Long> {
+        return database.mangasQueries
+            .getReadMangaIds()
+            .awaitAsList()
+            .toSet()
+    }
+
     override suspend fun getLibraryManga(): List<LibraryManga> {
         return getLibraryQuery()
             .awaitAsList()

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -24,6 +24,7 @@ CREATE TABLE chapters(
 
 CREATE INDEX chapters_manga_id_index ON chapters(manga_id);
 CREATE INDEX chapters_unread_by_manga_index ON chapters(manga_id, read) WHERE read = 0;
+CREATE INDEX chapters_read_progress_by_manga_index ON chapters(manga_id) WHERE read = 1 OR last_page_read != 0;
 CREATE INDEX idx_chapters_url ON chapters(url);
 
 CREATE TRIGGER update_last_modified_at_chapters

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -92,6 +92,11 @@ WHERE favorite = 0 AND _id IN (
     WHERE read = 1 OR last_page_read != 0
 );
 
+getReadMangaIds:
+SELECT DISTINCT manga_id
+FROM chapters
+WHERE read = 1 OR last_page_read != 0;
+
 getAllManga:
 SELECT *
 FROM mangas;

--- a/data/src/main/sqldelight/tachiyomi/migrations/41.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/41.sqm
@@ -1,0 +1,3 @@
+CREATE INDEX chapters_read_progress_by_manga_index
+ON chapters(manga_id)
+WHERE read = 1 OR last_page_read != 0;

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetReadMangaIds.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetReadMangaIds.kt
@@ -1,0 +1,12 @@
+package tachiyomi.domain.manga.interactor
+
+import tachiyomi.domain.manga.repository.MangaRepository
+
+class GetReadMangaIds(
+    private val mangaRepository: MangaRepository,
+) {
+
+    suspend fun await(): Set<Long> {
+        return mangaRepository.getReadMangaIds()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -20,6 +20,8 @@ interface MangaRepository {
 
     suspend fun getReadMangaNotInLibrary(): List<Manga>
 
+    suspend fun getReadMangaIds(): Set<Long>
+
     suspend fun getLibraryManga(): List<LibraryManga>
 
     fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -542,6 +542,8 @@
 
       <!-- Browse section -->
     <string name="pref_hide_in_library_items">Hide entries already in library</string>
+    <string name="pref_hide_read_items">Hide entries with reading history</string>
+    <string name="pref_hide_read_items_summary">Includes read chapters and saved reading progress</string>
 
       <!-- Data and storage section -->
     <string name="pref_storage_location">Storage location</string>


### PR DESCRIPTION
- Add optional "Hide entries with reading history" setting under Settings -> Browse
- Treat manga with read chapters or saved reading progress as previously read
- Apply this filter to browsing and feed for both sources and global
- Load reading-history IDs once per refresh and used shared filter across the browsing (disabled in migration)

### Images
Not included as not particularly relevant, just a new row/option in existing settings component