### PR TITLE
feat(storage): Add Google Drive cloud storage, streaming, and cloud backup support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,8 @@ android {
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")
         buildConfigField("String", "BUILD_TIME", "\"${getBuildTime(useLatestCommitTime = false)}\"")
         buildConfigField("boolean", "INCLUDE_UPDATER", "false")
+        buildConfigField("String", "GDRIVE_CLIENT_ID", "\"${project.findProperty("gdrive_client_id") ?: ""}\"")
+        buildConfigField("String", "GDRIVE_CLIENT_SECRET", "\"${project.findProperty("gdrive_client_secret") ?: ""}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -247,6 +247,11 @@
             android:foregroundServiceType="shortService" />
 
         <service
+            android:name=".data.storage.gdrive.GoogleDriveAuthService"
+            android:exported="false"
+            android:foregroundServiceType="shortService" />
+
+        <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"
             android:exported="false">

--- a/app/src/main/java/com/hippo/unifile/DriveFile.kt
+++ b/app/src/main/java/com/hippo/unifile/DriveFile.kt
@@ -1,0 +1,225 @@
+package com.hippo.unifile
+
+import android.app.Application
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import eu.kanade.tachiyomi.data.storage.gdrive.DriveEntry
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FilterOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * A [UniFile] backed by Google Drive.
+ *
+ * Declared in `com.hippo.unifile` because UniFile's constructor is package-private;
+ * that is the only reason this file sits outside the app's own package tree.
+ *
+ * Directory listings are cached briefly: the download bookkeeping walks the whole
+ * tree and would otherwise issue thousands of round trips per scan.
+ */
+class DriveFile private constructor(
+    parent: UniFile?,
+    private var entry: DriveEntry,
+) : UniFile(parent) {
+
+    private val service: GoogleDriveService by lazy { Injekt.get() }
+
+    val fileId: String get() = entry.id
+
+    override fun getUri(): Uri = Uri.parse(GoogleDriveService.URI_SCHEME + "://" + entry.id)
+
+    override fun getName(): String? = entry.name
+
+    override fun getType(): String? = if (entry.isFolder) null else entry.mimeType
+
+    /** Drive has no filesystem path; callers fall back to the URI. */
+    override fun getFilePath(): String? = null
+
+    override fun isDirectory(): Boolean = entry.isFolder
+
+    override fun isFile(): Boolean = !entry.isFolder
+
+    override fun lastModified(): Long = entry.modifiedTime?.let(::parseRfc3339) ?: 0L
+
+    override fun length(): Long = if (entry.isFolder) 0L else entry.lengthBytes
+
+    override fun canRead(): Boolean = true
+
+    override fun canWrite(): Boolean = true
+
+    /**
+     * A handle straight from [fromUri] carries no metadata yet. If the lookup cannot
+     * run — no network, or a main-thread caller — such a handle reports itself present
+     * rather than making the storage root look broken; the next real read decides.
+     */
+    override fun exists(): Boolean = runCatching {
+        val fresh = service.api.getEntry(entry.id)
+        if (fresh != null) entry = fresh
+        fresh != null && !fresh.trashed
+    }.getOrDefault(entry.name == null)
+
+    override fun listFiles(): Array<UniFile>? = runCatching {
+        childEntries().map { of(this, it) as UniFile }.toTypedArray()
+    }.getOrNull()
+
+    override fun listFiles(filter: FilenameFilter?): Array<UniFile>? {
+        val all = listFiles() ?: return null
+        if (filter == null) return all
+        return all.filter { filter.accept(this, it.name.orEmpty()) }.toTypedArray()
+    }
+
+    override fun findFile(displayName: String?): UniFile? {
+        if (displayName.isNullOrBlank()) return null
+        return childEntries()
+            .firstOrNull { it.name == displayName }
+            ?.let { of(this, it) }
+    }
+
+    override fun createFile(displayName: String?): UniFile? {
+        if (displayName.isNullOrBlank()) return null
+        findFile(displayName)?.let { return if (it.isFile) it else null }
+        return runCatching {
+            val created = service.api.createFile(entry.id, displayName, mimeOf(displayName))
+            DriveCache.invalidate(entry.id)
+            of(this, created)
+        }.getOrNull()
+    }
+
+    override fun createDirectory(displayName: String?): UniFile? {
+        if (displayName.isNullOrBlank()) return null
+        findFile(displayName)?.let { return if (it.isDirectory) it else null }
+        return runCatching {
+            val created = service.api.createFolder(entry.id, displayName)
+            DriveCache.invalidate(entry.id)
+            of(this, created)
+        }.getOrNull()
+    }
+
+    override fun renameTo(displayName: String?): Boolean {
+        if (displayName.isNullOrBlank()) return false
+        if (!service.api.rename(entry.id, displayName)) return false
+        entry = entry.copy(name = displayName)
+        invalidateParents()
+        return true
+    }
+
+    override fun delete(): Boolean {
+        val deleted = service.api.delete(entry.id)
+        if (deleted) invalidateParents()
+        return deleted
+    }
+
+    override fun openInputStream(): InputStream = service.api.openDownloadStream(entry.id)
+
+    override fun openOutputStream(): OutputStream = openOutputStream(false)
+
+    override fun openOutputStream(append: Boolean): OutputStream {
+        if (append) throw IOException("Drive files cannot be appended to")
+        val context = Injekt.get<Application>()
+        val staging = File.createTempFile("gdrive-", ".part", context.cacheDir)
+        return UploadOnCloseStream(FileOutputStream(staging), staging)
+    }
+
+    /** Random access would mean one range request per seek; every caller has a stream path. */
+    override fun createRandomAccessFile(mode: String?): UniRandomAccessFile =
+        throw IOException("Random access is not supported on Google Drive files")
+
+    private fun childEntries(): List<DriveEntry> {
+        if (!entry.isFolder) return emptyList()
+        return DriveCache.children(entry.id) { service.api.listChildren(entry.id) }
+    }
+
+    private fun invalidateParents() {
+        entry.parents?.forEach { DriveCache.invalidate(it) }
+    }
+
+    /** Buffers locally, then pushes the whole blob to Drive once the writer is done. */
+    private inner class UploadOnCloseStream(
+        stream: OutputStream,
+        private val staging: File,
+    ) : FilterOutputStream(stream) {
+        private var closed = false
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            out.write(b, off, len)
+        }
+
+        override fun close() {
+            if (closed) return
+            closed = true
+            try {
+                super.close()
+                val mime = (entry.mimeType ?: mimeOf(entry.name.orEmpty())).toMediaType()
+                service.api.uploadContent(entry.id, staging.asRequestBody(mime))
+                service.api.getEntry(entry.id)?.let { entry = it }
+                invalidateParents()
+            } finally {
+                staging.delete()
+            }
+        }
+    }
+
+    companion object {
+        fun of(parent: UniFile?, entry: DriveEntry): DriveFile = DriveFile(parent, entry)
+
+        /**
+         * Resolves `gdrive://<fileId>` back into a handle.
+         *
+         * Deliberately offline: [UniFile.fromUri] runs during startup on the main
+         * thread, where any network call would throw. Metadata is filled in the
+         * first time the file is actually touched.
+         */
+        fun fromUri(uri: Uri): DriveFile? {
+            if (uri.scheme != GoogleDriveService.URI_SCHEME) return null
+            val id = uri.host?.takeIf { it.isNotBlank() } ?: return null
+            return DriveFile(null, DriveEntry(id = id, mimeType = DriveEntry.FOLDER_MIME))
+        }
+
+        private fun mimeOf(name: String): String {
+            val extension = name.substringAfterLast('.', "").lowercase(Locale.US)
+            return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+                ?: "application/octet-stream"
+        }
+
+        private fun parseRfc3339(value: String): Long = runCatching {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
+                .apply { timeZone = TimeZone.getTimeZone("UTC") }
+                .parse(value)!!
+                .time
+        }.getOrDefault(0L)
+    }
+}
+
+/** Short-lived listing cache; a tree walk hits the same folders repeatedly. */
+private object DriveCache {
+    private const val TTL_MS = 30_000L
+
+    private val entries = HashMap<String, Pair<Long, List<DriveEntry>>>()
+
+    @Synchronized
+    fun children(folderId: String, loader: () -> List<DriveEntry>): List<DriveEntry> {
+        val now = System.currentTimeMillis()
+        entries[folderId]?.let { (stamp, cached) ->
+            if (now - stamp < TTL_MS) return cached
+        }
+        val fresh = loader()
+        entries[folderId] = now to fresh
+        return fresh
+    }
+
+    @Synchronized
+    fun invalidate(folderId: String) {
+        entries.remove(folderId)
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -34,6 +34,7 @@ import tachiyomi.domain.library.model.LibraryGroup
 import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.sort
 import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.BaseSortItem
@@ -46,6 +47,8 @@ import tachiyomi.presentation.core.components.SortItem
 import tachiyomi.presentation.core.components.TriStateItem
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 @Composable
 fun LibrarySettingsDialog(
@@ -99,11 +102,12 @@ private fun ColumnScope.FilterPage(
     screenModel: LibrarySettingsScreenModel,
 ) {
     val filterDownloaded by screenModel.libraryPreferences.filterDownloaded.collectAsState()
+    val filterCloud by screenModel.libraryPreferences.filterCloud.collectAsState()
     val downloadedOnly by screenModel.preferences.downloadedOnly.collectAsState()
     val autoUpdateMangaRestrictions by screenModel.libraryPreferences.autoUpdateMangaRestrictions.collectAsState()
 
     TriStateItem(
-        label = stringResource(MR.strings.label_downloaded),
+        label = stringResource(SYMR.strings.gdrive_filter_downloaded_local),
         state = if (downloadedOnly) {
             TriState.ENABLED_IS
         } else {
@@ -111,6 +115,11 @@ private fun ColumnScope.FilterPage(
         },
         enabled = !downloadedOnly,
         onClick = { screenModel.toggleFilter(LibraryPreferences::filterDownloaded) },
+    )
+    TriStateItem(
+        label = stringResource(SYMR.strings.gdrive_filter_stored_in_cloud),
+        state = filterCloud,
+        onClick = { screenModel.toggleFilter(LibraryPreferences::filterCloud) },
     )
     val filterUnread by screenModel.libraryPreferences.filterUnread.collectAsState()
     TriStateItem(

--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -33,6 +33,7 @@ import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LabeledCheckbox
 import tachiyomi.presentation.core.components.RadioItem
@@ -40,6 +41,7 @@ import tachiyomi.presentation.core.components.SortItem
 import tachiyomi.presentation.core.components.TriStateItem
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.theme.active
+import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
@@ -7,30 +7,42 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.more.settings.screen.SettingsDataScreen
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
+import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.Button
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 internal class StorageStep : OnboardingStep {
 
     private val storagePref = Injekt.get<StoragePreferences>().baseStorageDirectory
+    private val gdriveService = Injekt.get<GoogleDriveService>()
 
     private var _isComplete by mutableStateOf(false)
 
@@ -41,8 +53,13 @@ internal class StorageStep : OnboardingStep {
     override fun Content() {
         val context = LocalContext.current
         val handler = LocalUriHandler.current
+        val scope = rememberCoroutineScope()
 
         val pickStorageLocation = SettingsDataScreen.storageLocationPicker(storagePref)
+        val token by gdriveService.preferences.token.collectAsState()
+        val email by gdriveService.preferences.accountEmail.collectAsState()
+        val currentDir by storagePref.collectAsState()
+        val isDrive = token.isNotBlank() && currentDir.startsWith(GoogleDriveService.URI_SCHEME)
 
         Column(
             modifier = Modifier.padding(16.dp),
@@ -52,11 +69,46 @@ internal class StorageStep : OnboardingStep {
                 stringResource(
                     MR.strings.onboarding_storage_info,
                     stringResource(MR.strings.app_name),
-                    SettingsDataScreen.storageLocationText(storagePref),
+                    if (isDrive) {
+                        email.takeIf { it.isNotBlank() }
+                            ?.let { stringResource(SYMR.strings.gdrive_storage_label_account, it) }
+                            ?: stringResource(SYMR.strings.gdrive_storage_label)
+                    } else {
+                        SettingsDataScreen.storageLocationText(storagePref)
+                    },
                 ),
             )
 
+            // 1. Google Drive Cloud Storage (Recommended & Zero local footprint)
             Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    scope.launch {
+                        try {
+                            val session = withContext(Dispatchers.IO) { gdriveService.auth.beginSession() }
+                            gdriveService.completeSignIn(session)
+                            context.openInBrowser(session.authorizationUrl)
+                            context.toast(SYMR.strings.gdrive_sign_in_started)
+                        } catch (e: Exception) {
+                            gdriveService.logcat(LogPriority.ERROR, e) { "Google Drive sign-in failed" }
+                            context.toast(e.message ?: "Google Drive sign-in failed")
+                        }
+                    }
+                },
+            ) {
+                Text(
+                    stringResource(
+                        if (isDrive) {
+                            SYMR.strings.gdrive_onboarding_linked
+                        } else {
+                            SYMR.strings.gdrive_onboarding_use
+                        },
+                    ),
+                )
+            }
+
+            // 2. Local folder picker
+            OutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {
                     try {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -15,9 +16,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
@@ -123,6 +127,10 @@ object SettingsDataScreen : SearchableSettings {
             getStorageLocationPref(storagePreferences = storagePreferences),
             Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.pref_storage_location_info)),
 
+            // SY -->
+            googleDriveGroup(storagePreferences = storagePreferences),
+            // SY <--
+
             getBackupAndRestoreGroup(backupPreferences = backupPreferences),
             getDataGroup(),
             getExportGroup(),
@@ -202,8 +210,15 @@ object SettingsDataScreen : SearchableSettings {
     private fun getBackupAndRestoreGroup(backupPreferences: BackupPreferences): Preference.PreferenceGroup {
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
+        val scope = rememberCoroutineScope()
 
         val lastAutoBackup by backupPreferences.lastAutoBackupTimestamp.collectAsState()
+        val storagePreferences = remember { Injekt.get<tachiyomi.domain.storage.service.StoragePreferences>() }
+        val baseDir by storagePreferences.baseStorageDirectory.collectAsState()
+        val isDrive = baseDir.startsWith(eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService.URI_SCHEME)
+
+        var showCloudRestoreDialog by remember { mutableStateOf(false) }
+        var cloudBackups by remember { mutableStateOf<List<UniFile>>(emptyList()) }
 
         val chooseBackup = rememberLauncherForActivityResult(
             object : ActivityResultContracts.GetContent() {
@@ -219,6 +234,89 @@ object SettingsDataScreen : SearchableSettings {
             }
 
             navigator.push(RestoreBackupScreen(it.toString()))
+        }
+
+        val cloudItems = if (isDrive) {
+            listOf(
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(SYMR.strings.gdrive_backup_now),
+                    subtitle = stringResource(SYMR.strings.gdrive_backup_now_summary),
+                    onClick = {
+                        if (!BackupCreateJob.isManualJobRunning(context)) {
+                            BackupCreateJob.startNow(context, null, eu.kanade.tachiyomi.data.backup.create.BackupOptions())
+                            context.toast(SYMR.strings.gdrive_backup_started)
+                        } else {
+                            context.toast(MR.strings.backup_in_progress)
+                        }
+                    },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(SYMR.strings.gdrive_restore_from_cloud),
+                    subtitle = stringResource(SYMR.strings.gdrive_restore_from_cloud_summary),
+                    onClick = {
+                        if (!BackupRestoreJob.isRunning(context)) {
+                            scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                                val storageManager = Injekt.get<tachiyomi.domain.storage.service.StorageManager>()
+                                val backupDir = storageManager.getAutomaticBackupsDirectory()
+                                val files = backupDir?.listFiles()
+                                    ?.filter { it.name?.endsWith(".proto.gz") == true || it.name?.endsWith(".tachibk") == true }
+                                    ?.sortedByDescending { it.lastModified() }
+                                    .orEmpty()
+                                cloudBackups = files
+                                showCloudRestoreDialog = true
+                            }
+                        } else {
+                            context.toast(MR.strings.restore_in_progress)
+                        }
+                    },
+                ),
+            )
+        } else {
+            emptyList()
+        }
+
+        if (showCloudRestoreDialog) {
+            AlertDialog(
+                onDismissRequest = { showCloudRestoreDialog = false },
+                title = { Text(stringResource(SYMR.strings.gdrive_restore_dialog_title)) },
+                text = {
+                    if (cloudBackups.isEmpty()) {
+                        Text(stringResource(SYMR.strings.gdrive_restore_dialog_empty))
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            items(cloudBackups) { file ->
+                                val dateStr = remember(file) {
+                                    val sdf = java.text.SimpleDateFormat("yyyy/MM/dd HH:mm", java.util.Locale.getDefault())
+                                    sdf.format(java.util.Date(file.lastModified()))
+                                }
+                                val sizeStr = remember(file) {
+                                    android.text.format.Formatter.formatFileSize(context, file.length())
+                                }
+                                androidx.compose.material3.ListItem(
+                                    modifier = Modifier.clickable {
+                                        showCloudRestoreDialog = false
+                                        navigator.push(RestoreBackupScreen(file.uri.toString()))
+                                    },
+                                    headlineContent = {
+                                        Text(file.name ?: stringResource(SYMR.strings.gdrive_backup_file))
+                                    },
+                                    supportingContent = { Text("$dateStr • $sizeStr") },
+                                    leadingContent = {
+                                        Icon(Icons.Outlined.CloudDownload, contentDescription = null)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showCloudRestoreDialog = false }) {
+                        Text(stringResource(MR.strings.action_cancel))
+                    }
+                },
+            )
         }
 
         return Preference.PreferenceGroup(
@@ -267,7 +365,7 @@ object SettingsDataScreen : SearchableSettings {
                         },
                     )
                 },
-
+            ) + cloudItems + listOf(
                 // Automatic backups
                 Preference.PreferenceItem.ListPreference(
                     preference = backupPreferences.backupInterval,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -16,6 +16,7 @@ import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
@@ -34,6 +35,9 @@ object SettingsDownloadScreen : SearchableSettings {
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
 
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
+        val storagePreferences = remember { Injekt.get<tachiyomi.domain.storage.service.StoragePreferences>() }
+        val baseDir by storagePreferences.baseStorageDirectory.collectAsState()
+        val isDrive = baseDir.startsWith(eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService.URI_SCHEME)
         val parallelSourceLimit by downloadPreferences.parallelSourceLimit.collectAsState()
         val parallelPageLimit by downloadPreferences.parallelPageLimit.collectAsState()
         return listOf(
@@ -44,6 +48,8 @@ object SettingsDownloadScreen : SearchableSettings {
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.saveChaptersAsCBZ,
                 title = stringResource(MR.strings.save_chapter_as_cbz),
+                enabled = !isDrive,
+                subtitle = if (isDrive) stringResource(SYMR.strings.gdrive_cbz_unavailable) else null,
             ),
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.splitTallImages,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsGoogleDriveGroup.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsGoogleDriveGroup.kt
@@ -1,0 +1,123 @@
+package eu.kanade.presentation.more.settings.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import eu.kanade.presentation.more.settings.Preference
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
+import eu.kanade.tachiyomi.util.system.openInBrowser
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.storage.service.StoragePreferences
+import tachiyomi.i18n.sy.SYMR
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Lets the user link a Google Drive account and automatically point the storage location at it.
+ */
+@Composable
+internal fun googleDriveGroup(
+    storagePreferences: StoragePreferences,
+): Preference.PreferenceGroup {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val service = remember { Injekt.get<GoogleDriveService>() }
+
+    val token by service.preferences.token.collectAsState()
+    val email by service.preferences.accountEmail.collectAsState()
+    var showAdvanced by remember { mutableStateOf(false) }
+
+    val signedIn = token.isNotBlank()
+
+    val items = mutableListOf<Preference.PreferenceItem<out Any, out Any>>()
+
+    // 1. Primary Sign In / Sign Out button (automatically activates/deactivates cloud storage)
+    items.add(
+        Preference.PreferenceItem.TextPreference(
+            title = stringResource(
+                if (signedIn) SYMR.strings.pref_gdrive_sign_out else SYMR.strings.pref_gdrive_sign_in,
+            ),
+            subtitle = if (signedIn) {
+                val emailDisplay = email.takeIf { it.isNotBlank() }?.let { " ($it)" } ?: ""
+                stringResource(SYMR.strings.gdrive_signed_in_summary, emailDisplay)
+            } else {
+                stringResource(SYMR.strings.gdrive_sign_in_summary)
+            },
+            onClick = {
+                if (signedIn) {
+                    service.signOut()
+                    context.toast(SYMR.strings.gdrive_signed_out)
+                } else {
+                    scope.launch { signIn(context, service) }
+                }
+            },
+        ),
+    )
+
+    // 2. Advanced Settings toggle
+    items.add(
+        Preference.PreferenceItem.TextPreference(
+            title = stringResource(
+                if (showAdvanced) SYMR.strings.gdrive_advanced_hide else SYMR.strings.gdrive_advanced_show,
+            ),
+            subtitle = stringResource(SYMR.strings.gdrive_advanced_summary),
+            onClick = { showAdvanced = !showAdvanced },
+        ),
+    )
+
+    if (showAdvanced) {
+        items.add(
+            Preference.PreferenceItem.EditTextPreference(
+                preference = service.preferences.clientId,
+                title = stringResource(SYMR.strings.pref_gdrive_client_id),
+            ),
+        )
+        items.add(
+            Preference.PreferenceItem.EditTextPreference(
+                preference = service.preferences.clientSecret,
+                title = stringResource(SYMR.strings.pref_gdrive_client_secret),
+            ),
+        )
+    }
+
+    return Preference.PreferenceGroup(
+        title = stringResource(SYMR.strings.pref_category_google_drive),
+        preferenceItems = items,
+    )
+}
+
+/**
+ * Hands the user off to the browser, then blocks on the loopback socket until Google
+ * redirects back with an authorization code.
+ */
+private suspend fun signIn(
+    context: android.content.Context,
+    service: GoogleDriveService,
+) {
+    if (service.auth.getEffectiveClientId().isBlank()) {
+        context.toast(SYMR.strings.gdrive_credentials_missing)
+        return
+    }
+    try {
+        val session = withContext(Dispatchers.IO) { service.auth.beginSession() }
+        // Hand the wait to the service: opening the browser tears this screen down,
+        // and with it any coroutine scoped to the composition.
+        service.completeSignIn(session)
+        context.openInBrowser(session.authorizationUrl)
+        context.toast(SYMR.strings.gdrive_sign_in_started)
+    } catch (e: Exception) {
+        service.logcat(LogPriority.ERROR, e) { "Google Drive sign-in failed" }
+        context.toast(e.message ?: "Google Drive sign-in failed")
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/StorageInfo.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/StorageInfo.kt
@@ -9,17 +9,30 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import eu.kanade.tachiyomi.data.storage.gdrive.DriveStorageQuota
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
 import eu.kanade.tachiyomi.util.storage.DiskUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.theme.header
+import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.presentation.core.util.secondaryItemAlpha
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.File
 
 @Composable
@@ -27,15 +40,92 @@ fun StorageInfo(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val storages = remember { DiskUtil.getExternalStorages(context) }
+    val storagePreferences = remember { Injekt.get<StoragePreferences>() }
+    val googleDriveService = remember { Injekt.get<GoogleDriveService>() }
+    val baseDir by storagePreferences.baseStorageDirectory.collectAsState()
+    val token by googleDriveService.preferences.token.collectAsState()
+
+    val isDrive = token.isNotBlank() && baseDir.startsWith(GoogleDriveService.URI_SCHEME)
+
+    if (isDrive) {
+        DriveStorageInfo(modifier, googleDriveService)
+    } else {
+        val storages = remember { DiskUtil.getExternalStorages(context) }
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        ) {
+            storages.forEach {
+                StorageInfo(it)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DriveStorageInfo(
+    modifier: Modifier = Modifier,
+    googleDriveService: GoogleDriveService,
+) {
+    val context = LocalContext.current
+    var quota by remember { mutableStateOf<DriveStorageQuota?>(null) }
+    var userEmail by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            try {
+                val about = googleDriveService.api.getAbout()
+                if (about != null) {
+                    quota = about.storageQuota
+                    userEmail = about.user?.emailAddress ?: about.user?.displayName
+                    if (!userEmail.isNullOrBlank()) {
+                        googleDriveService.preferences.accountEmail.set(userEmail!!)
+                    }
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    val currentQuota = quota
+    val total = currentQuota?.totalBytes ?: 0L
+    val used = currentQuota?.usedBytes ?: 0L
+    val available = currentQuota?.availableBytes ?: 0L
+
+    val availableText = Formatter.formatFileSize(context, available)
+    val totalText = if (total > 0L) Formatter.formatFileSize(context, total) else "15 GB"
+    val emailText = userEmail ?: googleDriveService.preferences.accountEmail.get().takeIf { it.isNotBlank() }
 
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
     ) {
-        storages.forEach {
-            StorageInfo(it)
-        }
+        Text(
+            text = emailText?.takeIf { it.isNotBlank() }
+                ?.let { stringResource(SYMR.strings.gdrive_storage_label_account, it) }
+                ?: stringResource(SYMR.strings.gdrive_storage_label),
+            style = MaterialTheme.typography.header,
+        )
+
+        LinearProgressIndicator(
+            modifier = Modifier
+                .clip(MaterialTheme.shapes.small)
+                .fillMaxWidth()
+                .height(12.dp),
+            progress = {
+                if (total > 0L) (used.toFloat() / total.toFloat()).coerceIn(0f, 1f) else 0f
+            },
+        )
+
+        Text(
+            text = if (total > 0L) {
+                stringResource(MR.strings.available_disk_space_info, availableText, totalText)
+            } else {
+                stringResource(SYMR.strings.gdrive_storage_used, Formatter.formatFileSize(context, used))
+            },
+            modifier = Modifier.secondaryItemAlpha(),
+            style = MaterialTheme.typography.bodySmall,
+        )
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesFilterDialog.kt
@@ -15,19 +15,24 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
 import eu.kanade.tachiyomi.ui.updates.UpdatesSettingsScreenModel
 import tachiyomi.core.common.preference.getAndSet
+import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.domain.updates.service.UpdatesPreferences
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.SettingsItemsPaddings
 import tachiyomi.presentation.core.components.TriStateItem
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 @Composable
 fun UpdatesFilterDialog(
@@ -56,9 +61,16 @@ private fun ColumnScope.FilterSheet(
 ) {
     val filterDownloaded by screenModel.updatesPreferences.filterDownloaded.collectAsState()
     TriStateItem(
-        label = stringResource(MR.strings.label_downloaded),
+        label = stringResource(SYMR.strings.gdrive_filter_downloaded_local),
         state = filterDownloaded,
         onClick = { screenModel.toggleFilter(UpdatesPreferences::filterDownloaded) },
+    )
+
+    val filterCloud by screenModel.updatesPreferences.filterCloud.collectAsState()
+    TriStateItem(
+        label = stringResource(SYMR.strings.gdrive_filter_stored_in_cloud),
+        state = filterCloud,
+        onClick = { screenModel.toggleFilter(UpdatesPreferences::filterCloud) },
     )
 
     val filterUnread by screenModel.updatesPreferences.filterUnread.collectAsState()

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -31,6 +31,8 @@ import com.elvishew.xlog.printer.AndroidPrinter
 import com.elvishew.xlog.printer.Printer
 import com.elvishew.xlog.printer.file.backup.NeverBackupStrategy
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator
+import com.hippo.unifile.DriveFile
+import com.hippo.unifile.UniFile
 import eu.kanade.domain.DomainModule
 import eu.kanade.domain.SYDomainModule
 import eu.kanade.domain.base.BasePreferences
@@ -132,6 +134,8 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(SYDomainModule())
         InjektKoinBridge.startKoin(this)
         initExpensiveComponents(this)
+        // Teaches UniFile to resolve gdrive:// so Drive can back the storage location.
+        UniFile.addUriHandler { _, uri -> DriveFile.fromUri(uri) }
         // SY <--
 
         setupExhLogging() // EXH logging

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.data.backup
 
 import android.content.Context
 import android.net.Uri
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.backup.models.Backup
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.protobuf.ProtoBuf
@@ -22,7 +23,10 @@ class BackupDecoder(
      * Decode a potentially-gzipped backup.
      */
     fun decode(uri: Uri): Backup {
-        return context.contentResolver.openInputStream(uri)!!.use { inputStream ->
+        val stream = UniFile.fromUri(context, uri)?.openInputStream()
+            ?: context.contentResolver.openInputStream(uri)
+            ?: throw IOException("Cannot open backup file: $uri")
+        return stream.use { inputStream ->
             val source = inputStream.source().buffer()
 
             val peeked = source.peek().apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
@@ -113,10 +113,10 @@ class BackupCreateJob(private val context: Context, workerParams: WorkerParamete
             }
         }
 
-        fun startNow(context: Context, uri: Uri, options: BackupOptions) {
+        fun startNow(context: Context, uri: Uri? = null, options: BackupOptions = BackupOptions()) {
             val inputData = workDataOf(
-                IS_AUTO_BACKUP_KEY to false,
-                LOCATION_URI_KEY to uri.toString(),
+                IS_AUTO_BACKUP_KEY to (uri == null),
+                LOCATION_URI_KEY to uri?.toString(),
                 OPTIONS_KEY to options.asBooleanArray(),
             )
             val request = OneTimeWorkRequestBuilder<BackupCreateJob>()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import android.content.Context
 import androidx.core.net.toUri
 import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.storage.gdrive.DriveDownloadIndex
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveIndexManager
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.source.Source
 import kotlinx.coroutines.CancellationException
@@ -95,6 +98,8 @@ class DownloadCache(
 
     private val diskCacheFile: File
         get() = File(context.cacheDir, "dl_index_cache_v3")
+
+    private val gdriveIndexManager: GoogleDriveIndexManager by lazy { Injekt.get() }
 
     private val rootDownloadsDirMutex = Mutex()
     private var rootDownloadsDir = RootDirectory(storageManager.getDownloadsDirectory())
@@ -203,18 +208,21 @@ class DownloadCache(
      * @param manga the manga of the chapter.
      */
     suspend fun addChapter(chapterDirName: String, mangaUniFile: UniFile, manga: Manga) {
+        val source = sourceManager.get(manga.source)
+        val sourceDirName = source?.let { provider.getSourceDirName(it) }
+        val mangaDirName = provider.getMangaDirName(manga.ogTitle)
+
         rootDownloadsDirMutex.withLock {
             // Retrieve the cached source directory or cache a new one
             var sourceDir = rootDownloadsDir.sourceDirs[manga.source]
             if (sourceDir == null) {
-                val source = sourceManager.get(manga.source) ?: return
+                if (source == null) return
                 val sourceUniFile = provider.findSourceDir(source) ?: return
                 sourceDir = SourceDirectory(sourceUniFile)
                 rootDownloadsDir.sourceDirs += manga.source to sourceDir
             }
 
             // Retrieve the cached manga directory or cache a new one
-            val mangaDirName = provider.getMangaDirName(/* SY --> */ manga.ogTitle /* SY <-- */)
             var mangaDir = sourceDir.mangaDirs[mangaDirName]
             if (mangaDir == null) {
                 mangaDir = MangaDirectory(mangaUniFile)
@@ -223,6 +231,10 @@ class DownloadCache(
 
             // Save the chapter directory
             mangaDir.chapterDirs += chapterDirName
+        }
+
+        if (sourceDirName != null) {
+            gdriveIndexManager.addChapter(sourceDirName, mangaDirName, chapterDirName)
         }
 
         notifyChanges()
@@ -235,18 +247,24 @@ class DownloadCache(
      * @param manga the manga of the chapter.
      */
     suspend fun removeChapter(chapter: Chapter, manga: Manga) {
+        val source = sourceManager.get(manga.source)
+        val sourceDirName = source?.let { provider.getSourceDirName(it) }
+        val mangaDirName = provider.getMangaDirName(manga.ogTitle)
+        val removed = mutableListOf<String>()
+
         rootDownloadsDirMutex.withLock {
             val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return
-            val mangaDir = sourceDir.mangaDirs[
-                provider.getMangaDirName(
-                    /* SY --> */ manga.ogTitle, /* SY <-- */
-                ),
-            ] ?: return
+            val mangaDir = sourceDir.mangaDirs[mangaDirName] ?: return
             provider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).forEach {
                 if (it in mangaDir.chapterDirs) {
                     mangaDir.chapterDirs -= it
+                    removed += it
                 }
             }
+        }
+
+        if (sourceDirName != null && removed.isNotEmpty()) {
+            gdriveIndexManager.removeChapters(sourceDirName, mangaDirName, removed)
         }
 
         notifyChanges()
@@ -254,14 +272,22 @@ class DownloadCache(
 
     // SY -->
     suspend fun removeFolders(folders: List<String>, manga: Manga) {
+        val source = sourceManager.get(manga.source)
+        val sourceDirName = source?.let { provider.getSourceDirName(it) }
+        val mangaDirName = provider.getMangaDirName(manga.ogTitle)
+
         rootDownloadsDirMutex.withLock {
             val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return
-            val mangaDir = sourceDir.mangaDirs[provider.getMangaDirName(manga.ogTitle)] ?: return
+            val mangaDir = sourceDir.mangaDirs[mangaDirName] ?: return
             folders.forEach { chapter ->
                 if (chapter in mangaDir.chapterDirs) {
                     mangaDir.chapterDirs -= chapter
                 }
             }
+        }
+
+        if (sourceDirName != null && folders.isNotEmpty()) {
+            gdriveIndexManager.removeChapters(sourceDirName, mangaDirName, folders)
         }
     }
 
@@ -274,20 +300,26 @@ class DownloadCache(
      * @param manga the manga of the chapter.
      */
     suspend fun removeChapters(chapters: List<Chapter>, manga: Manga) {
+        val source = sourceManager.get(manga.source)
+        val sourceDirName = source?.let { provider.getSourceDirName(it) }
+        val mangaDirName = provider.getMangaDirName(manga.ogTitle)
+        val removed = mutableListOf<String>()
+
         rootDownloadsDirMutex.withLock {
             val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return
-            val mangaDir = sourceDir.mangaDirs[
-                provider.getMangaDirName(
-                    /* SY --> */ manga.ogTitle, /* SY <-- */
-                ),
-            ] ?: return
+            val mangaDir = sourceDir.mangaDirs[mangaDirName] ?: return
             chapters.forEach { chapter ->
                 provider.getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).forEach {
                     if (it in mangaDir.chapterDirs) {
                         mangaDir.chapterDirs -= it
+                        removed += it
                     }
                 }
             }
+        }
+
+        if (sourceDirName != null && removed.isNotEmpty()) {
+            gdriveIndexManager.removeChapters(sourceDirName, mangaDirName, removed)
         }
 
         notifyChanges()
@@ -299,12 +331,19 @@ class DownloadCache(
      * @param manga the manga to remove.
      */
     suspend fun removeManga(manga: Manga) {
+        val source = sourceManager.get(manga.source)
+        val sourceDirName = source?.let { provider.getSourceDirName(it) }
+        val mangaDirName = provider.getMangaDirName(manga.ogTitle)
+
         rootDownloadsDirMutex.withLock {
             val sourceDir = rootDownloadsDir.sourceDirs[manga.source] ?: return
-            val mangaDirName = provider.getMangaDirName(/* SY --> */ manga.ogTitle /* SY <-- */)
             if (sourceDir.mangaDirs.containsKey(mangaDirName)) {
                 sourceDir.mangaDirs -= mangaDirName
             }
+        }
+
+        if (sourceDirName != null) {
+            gdriveIndexManager.removeManga(sourceDirName, mangaDirName)
         }
 
         notifyChanges()
@@ -387,8 +426,44 @@ class DownloadCache(
 
             val sourceMap = sources.associate { provider.getSourceDirName(it).lowercase() to it.id }
 
+            val downloadsDir = storageManager.getDownloadsDirectory()
+            val isDriveStorage = downloadsDir?.uri?.scheme == GoogleDriveService.URI_SCHEME
+
+            if (isDriveStorage) {
+                val remoteIndex = gdriveIndexManager.loadRemoteIndex()
+                if (remoteIndex != null && remoteIndex.sources.isNotEmpty()) {
+                    rootDownloadsDirMutex.withLock {
+                        val updatedRootDir = RootDirectory(downloadsDir)
+                        val sourceDirsMap = mutableMapOf<Long, SourceDirectory>()
+
+                        for ((sourceDirNameLower, mangaMap) in remoteIndex.sources) {
+                            val sourceId = sourceMap[sourceDirNameLower] ?: continue
+                            val source = sourceManager.getOrStub(sourceId)
+                            val sourceUniFile = provider.findSourceDir(source) ?: continue
+                            val sourceDir = SourceDirectory(sourceUniFile)
+                            val mangaDirsMap = mutableMapOf<String, MangaDirectory>()
+
+                            for ((mangaDirName, chapterList) in mangaMap) {
+                                val mangaUniFile = sourceUniFile.findFile(mangaDirName) ?: continue
+                                val mangaDir = MangaDirectory(mangaUniFile)
+                                mangaDir.chapterDirs = chapterList.toMutableSet()
+                                mangaDirsMap[mangaDirName] = mangaDir
+                            }
+                            sourceDir.mangaDirs = mangaDirsMap
+                            sourceDirsMap[sourceId] = sourceDir
+                        }
+                        updatedRootDir.sourceDirs = sourceDirsMap
+                        rootDownloadsDir = updatedRootDir
+                    }
+                    _isInitializing.emit(false)
+                    lastRenew = System.currentTimeMillis()
+                    notifyChanges()
+                    return@launchIO
+                }
+            }
+
             rootDownloadsDirMutex.withLock {
-                val updatedRootDir = RootDirectory(storageManager.getDownloadsDirectory())
+                val updatedRootDir = RootDirectory(downloadsDir)
 
                 updatedRootDir.sourceDirs = updatedRootDir.dir?.listFiles().orEmpty()
                     .filter { it.isDirectory && !it.name.isNullOrBlank() }
@@ -427,6 +502,20 @@ class DownloadCache(
                     .awaitAll()
 
                 rootDownloadsDir = updatedRootDir
+
+                if (isDriveStorage) {
+                    val sourcesMap = mutableMapOf<String, Map<String, List<String>>>()
+                    rootDownloadsDir.sourceDirs.forEach { (sourceId, sourceDir) ->
+                        val source = sourceManager.getOrStub(sourceId)
+                        val sourceDirName = provider.getSourceDirName(source).lowercase()
+                        val mangaMap = mutableMapOf<String, List<String>>()
+                        sourceDir.mangaDirs.forEach { (mangaDirName, mangaDir) ->
+                            mangaMap[mangaDirName] = mangaDir.chapterDirs.toList()
+                        }
+                        sourcesMap[sourceDirName] = mangaMap
+                    }
+                    gdriveIndexManager.setIndex(DriveDownloadIndex(sources = sourcesMap))
+                }
             }
 
             _isInitializing.emit(false)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -289,6 +289,16 @@ class Downloader(
         val chaptersToQueue = chapters.asSequence()
             // Filter out those already downloaded.
             .filter {
+                !cache.isChapterDownloaded(
+                    it.name,
+                    it.scanlator,
+                    it.url,
+                    /* SY --> */ manga.ogTitle, /* SY <-- */
+                    source.id,
+                    skipCache = false,
+                )
+            }
+            .filter {
                 provider.findChapterDir(
                     it.name,
                     it.scanlator,
@@ -364,6 +374,29 @@ class Downloader(
             download.chapter.scanlator,
             download.chapter.url,
         )
+
+        // Check if chapter was already downloaded previously on Drive or local disk
+        val isAlreadyDownloaded = cache.isChapterDownloaded(
+            download.chapter.name,
+            download.chapter.scanlator,
+            download.chapter.url,
+            download.manga.ogTitle,
+            download.source.id,
+            skipCache = false,
+        ) || provider.findChapterDir(
+            download.chapter.name,
+            download.chapter.scanlator,
+            download.chapter.url,
+            download.manga.ogTitle,
+            download.source,
+        ) != null
+
+        if (isAlreadyDownloaded) {
+            cache.addChapter(chapterDirname, mangaDir, download.manga)
+            download.status = Download.State.DOWNLOADED
+            return
+        }
+
         val tmpDir = mangaDir.createDirectory(chapterDirname + TMP_DIR_SUFFIX)!!
 
         try {
@@ -427,14 +460,21 @@ class Downloader(
             )
 
             // Only rename the directory if it's downloaded
-            if (downloadPreferences.saveChaptersAsCBZ.get()) {
+            val isDrive = mangaDir.uri.scheme == eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService.URI_SCHEME
+            if (downloadPreferences.saveChaptersAsCBZ.get() && !isDrive) {
                 archiveChapter(mangaDir, chapterDirname, tmpDir)
             } else {
+                val existing = mangaDir.findFile(chapterDirname)
+                if (existing != null && existing.uri != tmpDir.uri) {
+                    existing.delete()
+                }
                 tmpDir.renameTo(chapterDirname)
             }
             cache.addChapter(chapterDirname, mangaDir, download.manga)
 
-            DiskUtil.createNoMediaFile(tmpDir, context)
+            if (!isDrive) {
+                DiskUtil.createNoMediaFile(tmpDir, context)
+            }
 
             download.status = Download.State.DOWNLOADED
         } catch (error: Throwable) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -68,6 +68,11 @@ object Notifications {
     const val ID_INCOGNITO_MODE = -701
 
     /**
+     * Notification id used while a Google Drive account is being linked.
+     */
+    const val ID_GDRIVE_AUTH = -601
+
+    /**
      * Notification channel and ids used for app and extension updates.
      */
     private const val GROUP_APK_UPDATES = "group_apk_updates"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/DriveEntry.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/DriveEntry.kt
@@ -1,0 +1,54 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** A single file or folder as returned by the Drive v3 `files` resource. */
+@Serializable
+data class DriveEntry(
+    val id: String,
+    val name: String? = null,
+    val mimeType: String? = null,
+    val size: String? = null,
+    @SerialName("modifiedTime") val modifiedTime: String? = null,
+    val trashed: Boolean = false,
+    val parents: List<String>? = null,
+) {
+    val isFolder: Boolean get() = mimeType == FOLDER_MIME
+
+    val lengthBytes: Long get() = size?.toLongOrNull() ?: 0L
+
+    companion object {
+        const val FOLDER_MIME = "application/vnd.google-apps.folder"
+    }
+}
+
+@Serializable
+data class DriveFileList(
+    val files: List<DriveEntry> = emptyList(),
+    val nextPageToken: String? = null,
+)
+
+@Serializable
+data class DriveAbout(
+    val storageQuota: DriveStorageQuota? = null,
+    val user: DriveUser? = null,
+)
+
+@Serializable
+data class DriveStorageQuota(
+    val limit: String? = null,
+    val usage: String? = null,
+    val usageInDrive: String? = null,
+    val usageInDriveTrash: String? = null,
+) {
+    val totalBytes: Long get() = limit?.toLongOrNull() ?: 0L
+    val usedBytes: Long get() = usage?.toLongOrNull() ?: 0L
+    val availableBytes: Long get() = (totalBytes - usedBytes).coerceAtLeast(0L)
+}
+
+@Serializable
+data class DriveUser(
+    val displayName: String? = null,
+    val emailAddress: String? = null,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveApi.kt
@@ -1,0 +1,174 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import android.os.StrictMode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Blocking wrapper over the Drive v3 REST API.
+ *
+ * Blocking on purpose: every caller comes in through [com.hippo.unifile.UniFile],
+ * whose contract is synchronous, and those calls already run on IO dispatchers.
+ */
+class GoogleDriveApi(
+    private val client: OkHttpClient,
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    private inline fun <T> allowNetwork(block: () -> T): T {
+        val oldPolicy = StrictMode.getThreadPolicy()
+        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder().permitAll().build())
+        return try {
+            block()
+        } finally {
+            StrictMode.setThreadPolicy(oldPolicy)
+        }
+    }
+
+    private fun body(response: okhttp3.Response): String {
+        response.use {
+            val text = it.body.string()
+            if (!it.isSuccessful) {
+                throw IOException("Drive API ${it.code}: ${text.take(300)}")
+            }
+            return text
+        }
+    }
+
+    /** Lists every non-trashed child of [parentId], following pagination. */
+    fun listChildren(parentId: String): List<DriveEntry> = allowNetwork {
+        val out = mutableListOf<DriveEntry>()
+        var pageToken: String? = null
+        do {
+            val url = FILES_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("q", "'$parentId' in parents and trashed = false")
+                .addQueryParameter("fields", "nextPageToken, files($ENTRY_FIELDS)")
+                .addQueryParameter("pageSize", "1000")
+                .addQueryParameter("supportsAllDrives", "true")
+                .apply { pageToken?.let { addQueryParameter("pageToken", it) } }
+                .build()
+            val page = json.decodeFromString<DriveFileList>(
+                body(client.newCall(Request.Builder().url(url).build()).execute()),
+            )
+            out += page.files
+            pageToken = page.nextPageToken
+        } while (pageToken != null)
+        out
+    }
+
+    fun getEntry(fileId: String): DriveEntry? = allowNetwork {
+        try {
+            val url = "$FILES_URL/$fileId".toHttpUrl().newBuilder()
+                .addQueryParameter("fields", ENTRY_FIELDS)
+                .build()
+            json.decodeFromString<DriveEntry>(
+                body(client.newCall(Request.Builder().url(url).build()).execute()),
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun createFolder(parentId: String, name: String): DriveEntry =
+        createMetadata(parentId, name, DriveEntry.FOLDER_MIME)
+
+    fun createFile(parentId: String, name: String, mimeType: String): DriveEntry =
+        createMetadata(parentId, name, mimeType)
+
+    private fun createMetadata(parentId: String, name: String, mimeType: String): DriveEntry = allowNetwork {
+        val payload = buildString {
+            append("{\"name\":").append(quote(name))
+            append(",\"mimeType\":").append(quote(mimeType))
+            append(",\"parents\":[").append(quote(parentId)).append("]}")
+        }
+        val url = FILES_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("fields", ENTRY_FIELDS)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .post(payload.toRequestBody(JSON_MIME))
+            .build()
+        json.decodeFromString(body(client.newCall(request).execute()))
+    }
+
+    fun rename(fileId: String, newName: String): Boolean = allowNetwork {
+        try {
+            val request = Request.Builder()
+                .url("$FILES_URL/$fileId")
+                .patch("{\"name\":${quote(newName)}}".toRequestBody(JSON_MIME))
+                .build()
+            body(client.newCall(request).execute())
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    fun delete(fileId: String): Boolean = allowNetwork {
+        try {
+            val request = Request.Builder().url("$FILES_URL/$fileId").delete().build()
+            client.newCall(request).execute().use { it.isSuccessful }
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /** Caller owns the returned stream and must close it. */
+    fun openDownloadStream(fileId: String): InputStream = allowNetwork {
+        val url = "$FILES_URL/$fileId".toHttpUrl().newBuilder()
+            .addQueryParameter("alt", "media")
+            .build()
+        val response = client.newCall(Request.Builder().url(url).build()).execute()
+        if (!response.isSuccessful) {
+            val code = response.code
+            response.close()
+            throw IOException("Drive download failed: $code")
+        }
+        response.body.byteStream()
+    }
+
+    /** Replaces the whole content of an existing Drive file. */
+    fun uploadContent(fileId: String, requestBody: RequestBody) = allowNetwork {
+        val url = "$UPLOAD_URL/$fileId".toHttpUrl().newBuilder()
+            .addQueryParameter("uploadType", "media")
+            .build()
+        body(
+            client.newCall(Request.Builder().url(url).patch(requestBody).build()).execute(),
+        )
+    }
+
+    /** Fetches the user's storage quota and account details. */
+    fun getAbout(): DriveAbout? = allowNetwork {
+        try {
+            val url = ABOUT_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("fields", "storageQuota,user")
+                .build()
+            json.decodeFromString<DriveAbout>(
+                body(client.newCall(Request.Builder().url(url).build()).execute()),
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun quote(value: String): String = JsonPrimitive(value).toString()
+
+    companion object {
+        private const val FILES_URL = "https://www.googleapis.com/drive/v3/files"
+        private const val UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files"
+        private const val ABOUT_URL = "https://www.googleapis.com/drive/v3/about"
+        private const val ENTRY_FIELDS = "id,name,mimeType,size,modifiedTime,trashed,parents"
+        private val JSON_MIME = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveAuth.kt
@@ -1,0 +1,269 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import android.util.Base64
+import kotlinx.serialization.json.Json
+import logcat.LogPriority
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import tachiyomi.core.common.util.system.logcat
+import java.io.IOException
+import java.net.ServerSocket
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * OAuth 2.0 for installed apps, loopback variant.
+ *
+ * The redirect lands on a short-lived local socket, so nothing has to be baked into
+ * the manifest and the user can swap credentials without a rebuild. The listener
+ * binds every interface — a loopback-only bind is refused on some devices — and
+ * rejects any caller that is not on the loopback address.
+ */
+class GoogleDriveAuth(
+    private val client: OkHttpClient,
+    private val preferences: GoogleDrivePreferences,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    class Session(
+        val authorizationUrl: String,
+        internal val verifier: String,
+        internal val server: ServerSocket,
+    ) {
+        val redirectUri: String get() = "http://127.0.0.1:${server.localPort}"
+    }
+
+    fun getEffectiveClientId(): String {
+        val custom = preferences.clientId.get().trim()
+        return custom.ifBlank { eu.kanade.tachiyomi.BuildConfig.GDRIVE_CLIENT_ID.ifBlank { DEFAULT_CLIENT_ID } }
+    }
+
+    fun getEffectiveClientSecret(): String {
+        val custom = preferences.clientSecret.get().trim()
+        return custom.ifBlank { eu.kanade.tachiyomi.BuildConfig.GDRIVE_CLIENT_SECRET.ifBlank { DEFAULT_CLIENT_SECRET } }
+    }
+
+    /** Opens the loopback socket and builds the URL the user must visit. */
+    fun beginSession(): Session {
+        val clientId = getEffectiveClientId()
+        require(clientId.isNotBlank()) { "Google Drive client id is not configured" }
+
+        val verifier = randomUrlSafe(64)
+        val challenge = base64Url(
+            MessageDigest.getInstance("SHA-256").digest(verifier.toByteArray(Charsets.US_ASCII)),
+        )
+        val server = ServerSocket(0, 50, null).apply {
+            soTimeout = REDIRECT_TIMEOUT_MS
+        }
+        val redirect = "http://127.0.0.1:${server.localPort}"
+
+        val url = okhttp3.HttpUrl.Builder()
+            .scheme("https")
+            .host("accounts.google.com")
+            .addPathSegments("o/oauth2/v2/auth")
+            .addQueryParameter("client_id", clientId)
+            .addQueryParameter("redirect_uri", redirect)
+            .addQueryParameter("response_type", "code")
+            .addQueryParameter("scope", SCOPE)
+            .addQueryParameter("code_challenge", challenge)
+            .addQueryParameter("code_challenge_method", "S256")
+            .addQueryParameter("access_type", "offline")
+            .addQueryParameter("prompt", "consent")
+            .build()
+            .toString()
+
+        return Session(url, verifier, server)
+    }
+
+    /**
+     * Blocks on the local socket until Google redirects back, then trades the
+     * authorization code for tokens. Always closes the socket.
+     */
+    fun awaitToken(session: Session): GoogleDriveOAuth {
+        val deadline = System.currentTimeMillis() + REDIRECT_TIMEOUT_MS
+        var authCode: String? = null
+        var oauthError: String? = null
+
+        session.server.use { server ->
+            while (authCode == null && oauthError == null && System.currentTimeMillis() < deadline) {
+                try {
+                    val remaining = (deadline - System.currentTimeMillis()).toInt().coerceAtLeast(1000)
+                    server.soTimeout = remaining
+                    server.accept().use { socket ->
+                        // The listener binds every interface because a loopback-only
+                        // bind is refused on some devices, so drop anything that did
+                        // not originate on this device before reading a byte of it.
+                        if (!socket.inetAddress.isLoopbackAddress) {
+                            logcat(LogPriority.WARN) { "Drive auth: rejected non-local caller" }
+                            return@use
+                        }
+                        val reader = socket.getInputStream().bufferedReader(Charsets.UTF_8)
+                        val requestLine = reader.readLine().orEmpty()
+                        // Only the request target: the query string carries the
+                        // authorization code and must never reach the log.
+                        logcat(LogPriority.INFO) {
+                            "Drive auth callback: ${requestLine.substringBefore('?').trim()}"
+                        }
+
+                        if (requestLine.startsWith("OPTIONS", ignoreCase = true) ||
+                            requestLine.contains("/probe", ignoreCase = true)
+                        ) {
+                            socket.getOutputStream().apply {
+                                write(PREFLIGHT_RESPONSE)
+                                flush()
+                            }
+                        } else {
+                            val code = extractCode(requestLine)
+                            val error = extractError(requestLine)
+                            if (code != null) {
+                                authCode = code
+                                socket.getOutputStream().apply {
+                                    write(buildResponse(SUCCESS_PAGE))
+                                    flush()
+                                }
+                            } else if (error != null) {
+                                oauthError = error
+                                socket.getOutputStream().apply {
+                                    write(buildResponse(errorPage(error)))
+                                    flush()
+                                }
+                            } else {
+                                // Probe or generic GET without code (e.g. favicon)
+                                socket.getOutputStream().apply {
+                                    write(buildResponse(SUCCESS_PAGE))
+                                    flush()
+                                }
+                            }
+                        }
+                    }
+                } catch (_: java.net.SocketTimeoutException) {
+                    break
+                } catch (e: Exception) {
+                    logcat(LogPriority.WARN, e) { "gdrive: socket exception while awaiting token" }
+                }
+            }
+        }
+
+        oauthError?.let {
+            throw IOException("Google authorization failed: $it")
+        }
+
+        val finalCode = authCode
+            ?: throw IOException("Google did not return an authorization code (timeout or connection lost)")
+
+        return exchange(
+            FormBody.Builder()
+                .add("code", finalCode)
+                .add("client_id", getEffectiveClientId())
+                .add("client_secret", getEffectiveClientSecret())
+                .add("redirect_uri", session.redirectUri)
+                .add("grant_type", "authorization_code")
+                .add("code_verifier", session.verifier)
+                .build(),
+        )
+    }
+
+    fun refresh(current: GoogleDriveOAuth): GoogleDriveOAuth {
+        val refreshToken = current.refreshToken
+            ?: throw IOException("Google Drive: no refresh token stored, sign in again")
+        return exchange(
+            FormBody.Builder()
+                .add("refresh_token", refreshToken)
+                .add("client_id", getEffectiveClientId())
+                .add("client_secret", getEffectiveClientSecret())
+                .add("grant_type", "refresh_token")
+                .build(),
+            refreshTokenFallback = refreshToken,
+        )
+    }
+
+    private fun exchange(form: FormBody, refreshTokenFallback: String? = null): GoogleDriveOAuth {
+        val request = Request.Builder().url(TOKEN_URL).post(form).build()
+        client.newCall(request).execute().use { response ->
+            val text = response.body.string()
+            if (!response.isSuccessful) {
+                throw IOException("Google token endpoint ${response.code}: ${text.take(300)}")
+            }
+            return json.decodeFromString<GoogleDriveOAuth>(text).stamped(refreshTokenFallback)
+        }
+    }
+
+    private fun extractCode(requestLine: String): String? {
+        // "GET /?code=4/0Ax...&scope=... HTTP/1.1"
+        val target = requestLine.split(' ').getOrNull(1) ?: return null
+        return target.substringAfter('?', "")
+            .split('&')
+            .map { it.split('=', limit = 2) }
+            .firstOrNull { it.size == 2 && it[0] == "code" }
+            ?.get(1)
+    }
+
+    private fun extractError(requestLine: String): String? {
+        // "GET /?error=access_denied HTTP/1.1"
+        val target = requestLine.split(' ').getOrNull(1) ?: return null
+        return target.substringAfter('?', "")
+            .split('&')
+            .map { it.split('=', limit = 2) }
+            .firstOrNull { it.size == 2 && it[0] == "error" }
+            ?.get(1)
+    }
+
+    private fun randomUrlSafe(bytes: Int): String {
+        val random = ByteArray(bytes).also { SecureRandom().nextBytes(it) }
+        return base64Url(random)
+    }
+
+    private fun base64Url(bytes: ByteArray): String =
+        Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+
+    companion object {
+        const val DEFAULT_CLIENT_ID = ""
+        const val DEFAULT_CLIENT_SECRET = ""
+
+        /** Only files this app creates. Non-sensitive, so no Google review is needed. */
+        const val SCOPE = "https://www.googleapis.com/auth/drive.file"
+        private const val TOKEN_URL = "https://oauth2.googleapis.com/token"
+        private const val REDIRECT_TIMEOUT_MS = 5 * 60 * 1000
+
+        private fun buildResponse(body: String, contentType: String = "text/html; charset=utf-8"): ByteArray {
+            val bodyBytes = body.toByteArray(Charsets.UTF_8)
+            val headers = buildString {
+                append("HTTP/1.1 200 OK\r\n")
+                append("Content-Type: ").append(contentType).append("\r\n")
+                append("Content-Length: ").append(bodyBytes.size).append("\r\n")
+                append("Access-Control-Allow-Origin: *\r\n")
+                append("Access-Control-Allow-Private-Network: true\r\n")
+                append("Access-Control-Allow-Methods: GET, POST, OPTIONS, HEAD\r\n")
+                append("Access-Control-Allow-Headers: *\r\n")
+                append("Connection: close\r\n\r\n")
+            }
+            return headers.toByteArray(Charsets.UTF_8) + bodyBytes
+        }
+
+        private val PREFLIGHT_RESPONSE: ByteArray = buildResponse("")
+
+        private val SUCCESS_PAGE = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>TachiyomiSY</title></head>
+            <body style="font-family:system-ui,-apple-system,sans-serif;text-align:center;padding:4em 1em;background:#121212;color:#ffffff;">
+              <h2 style="color:#4CAF50;margin-bottom:0.5em;">Signed in</h2>
+              <p style="color:#cccccc;font-size:1.1em;">You can close this tab and go back to the app.</p>
+            </body>
+            </html>
+        """.trimIndent()
+
+        private fun errorPage(error: String) = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>TachiyomiSY</title></head>
+            <body style="font-family:system-ui,-apple-system,sans-serif;text-align:center;padding:4em 1em;background:#121212;color:#ffffff;">
+              <h2 style="color:#F44336;margin-bottom:0.5em;">Sign-in failed</h2>
+              <p style="color:#cccccc;font-size:1.1em;">$error</p>
+              <p style="color:#999999;">Go back to the app and try again.</p>
+            </body>
+            </html>
+        """.trimIndent()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveAuthService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveAuthService.kt
@@ -1,0 +1,72 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.content.ContextCompat
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import logcat.LogPriority
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.i18n.sy.SYMR
+
+/**
+ * Keeps the process alive while the user authenticates with Google in the browser.
+ *
+ * Without it the backgrounded app can be frozen before the redirect comes back,
+ * which drops the loopback listener waiting for the authorization code.
+ */
+class GoogleDriveAuthService : Service() {
+
+    override fun onCreate() {
+        super.onCreate()
+        try {
+            val notification = notificationBuilder(Notifications.CHANNEL_COMMON) {
+                setSmallIcon(R.drawable.ic_tachi)
+                setAutoCancel(true)
+                setOngoing(true)
+                setShowWhen(false)
+                setContentTitle(stringResource(SYMR.strings.pref_gdrive_sign_in))
+                setContentText(stringResource(SYMR.strings.gdrive_sign_in_started))
+            }.build()
+            startForeground(Notifications.ID_GDRIVE_AUTH, notification)
+        } catch (e: Exception) {
+            // Never leave the service running without a foreground notification:
+            // the system kills the process for it.
+            logcat(LogPriority.WARN, e) { "Could not start Drive auth notification" }
+            stopSelf()
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        fun start(context: Context) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, GoogleDriveAuthService::class.java),
+                )
+            }.onFailure {
+                context.logcat(LogPriority.WARN, it) { "Could not start Drive auth service" }
+            }
+        }
+
+        /**
+         * Uses stopService rather than a stop-action Intent: starting a service from
+         * the background is blocked on Android 8+, which would strand the notification.
+         */
+        fun stop(context: Context) {
+            runCatching {
+                context.stopService(Intent(context, GoogleDriveAuthService::class.java))
+            }.onFailure {
+                context.logcat(LogPriority.WARN, it) { "Could not stop Drive auth service" }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveIndexManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveIndexManager.kt
@@ -1,0 +1,186 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import logcat.LogPriority
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.core.common.util.system.logcat
+import java.io.InputStream
+
+@Serializable
+data class DriveDownloadIndex(
+    val version: Int = 1,
+    val lastUpdated: Long = System.currentTimeMillis(),
+    // sourceDirName.lowercase() -> (mangaDirName -> list of chapterDirNames)
+    val sources: Map<String, Map<String, List<String>>> = emptyMap(),
+)
+
+/**
+ * Manages the single `downloads_index.json` file stored in the Google Drive root folder.
+ *
+ * This allows instant 1-request synchronization of the entire cloud download library
+ * across devices, avoiding recursive directory scanning on large libraries.
+ */
+class GoogleDriveIndexManager(
+    private val service: GoogleDriveService,
+) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val mutex = Mutex()
+    private var currentIndex = DriveDownloadIndex()
+    private var indexFileId: String? = null
+    private var syncJob: Job? = null
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        prettyPrint = true
+    }
+
+    /**
+     * Loads the index from Google Drive root directory in a single GET request.
+     * Returns null if the file does not exist yet or drive is not signed in.
+     */
+    suspend fun loadRemoteIndex(): DriveDownloadIndex? = mutex.withLock {
+        if (!service.isSignedIn) return null
+        try {
+            val rootId = service.ensureRootFolder()
+            val children = service.api.listChildren(rootId)
+            val fileEntry = children.firstOrNull { it.name == INDEX_FILENAME && !it.isFolder }
+            if (fileEntry != null) {
+                indexFileId = fileEntry.id
+                val stream: InputStream = service.api.openDownloadStream(fileEntry.id)
+                val content = stream.use { it.reader().readText() }
+                val parsed = json.decodeFromString<DriveDownloadIndex>(content)
+                currentIndex = parsed
+                logcat(LogPriority.INFO) { "Google Drive download index loaded: ${parsed.sources.size} sources" }
+                return parsed
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to load Google Drive download index" }
+        }
+        return null
+    }
+
+    fun getCachedIndex(): DriveDownloadIndex = currentIndex
+
+    fun setIndex(index: DriveDownloadIndex) {
+        currentIndex = index
+        scheduleSave()
+    }
+
+    fun addChapter(sourceDirName: String, mangaDirName: String, chapterDirName: String) {
+        scope.launch {
+            mutex.withLock {
+                val sourceKey = sourceDirName.lowercase()
+                val currentSources = currentIndex.sources.toMutableMap()
+                val currentMangaMap = currentSources[sourceKey]?.toMutableMap() ?: mutableMapOf()
+                val currentChapters = currentMangaMap[mangaDirName]?.toMutableSet() ?: mutableSetOf()
+
+                currentChapters.add(chapterDirName)
+                currentMangaMap[mangaDirName] = currentChapters.toList()
+                currentSources[sourceKey] = currentMangaMap
+
+                currentIndex = currentIndex.copy(
+                    lastUpdated = System.currentTimeMillis(),
+                    sources = currentSources,
+                )
+            }
+            scheduleSave()
+        }
+    }
+
+    fun removeChapters(sourceDirName: String, mangaDirName: String, chapterDirNames: List<String>) {
+        scope.launch {
+            mutex.withLock {
+                val sourceKey = sourceDirName.lowercase()
+                val currentSources = currentIndex.sources.toMutableMap()
+                val currentMangaMap = currentSources[sourceKey]?.toMutableMap() ?: return@launch
+                val currentChapters = currentMangaMap[mangaDirName]?.toMutableSet() ?: return@launch
+
+                currentChapters.removeAll(chapterDirNames.toSet())
+                if (currentChapters.isEmpty()) {
+                    currentMangaMap.remove(mangaDirName)
+                } else {
+                    currentMangaMap[mangaDirName] = currentChapters.toList()
+                }
+
+                if (currentMangaMap.isEmpty()) {
+                    currentSources.remove(sourceKey)
+                } else {
+                    currentSources[sourceKey] = currentMangaMap
+                }
+
+                currentIndex = currentIndex.copy(
+                    lastUpdated = System.currentTimeMillis(),
+                    sources = currentSources,
+                )
+            }
+            scheduleSave()
+        }
+    }
+
+    fun removeManga(sourceDirName: String, mangaDirName: String) {
+        scope.launch {
+            mutex.withLock {
+                val sourceKey = sourceDirName.lowercase()
+                val currentSources = currentIndex.sources.toMutableMap()
+                val currentMangaMap = currentSources[sourceKey]?.toMutableMap() ?: return@launch
+
+                currentMangaMap.remove(mangaDirName)
+                if (currentMangaMap.isEmpty()) {
+                    currentSources.remove(sourceKey)
+                } else {
+                    currentSources[sourceKey] = currentMangaMap
+                }
+
+                currentIndex = currentIndex.copy(
+                    lastUpdated = System.currentTimeMillis(),
+                    sources = currentSources,
+                )
+            }
+            scheduleSave()
+        }
+    }
+
+    private fun scheduleSave() {
+        syncJob?.cancel()
+        syncJob = scope.launch {
+            delay(1500) // Debounce saves by 1.5s
+            saveToRemote()
+        }
+    }
+
+    private suspend fun saveToRemote() = mutex.withLock {
+        if (!service.isSignedIn) return
+        try {
+            val rootId = service.ensureRootFolder()
+            val content = json.encodeToString(currentIndex)
+            val body = content.toRequestBody(JSON_MIME)
+
+            var fileId = indexFileId
+            if (fileId == null) {
+                val children = service.api.listChildren(rootId)
+                val existing = children.firstOrNull { it.name == INDEX_FILENAME && !it.isFolder }
+                fileId = existing?.id ?: service.api.createFile(rootId, INDEX_FILENAME, "application/json").id
+                indexFileId = fileId
+            }
+            service.api.uploadContent(fileId, body)
+            logcat(LogPriority.INFO) { "Google Drive download index saved to cloud (${content.length} bytes)" }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to save Google Drive download index to cloud" }
+        }
+    }
+
+    companion object {
+        const val INDEX_FILENAME = "downloads_index.json"
+        private val JSON_MIME = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveInterceptor.kt
@@ -1,0 +1,30 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+/** Attaches the bearer token to every Drive call, refreshing it when it has aged out. */
+class GoogleDriveInterceptor(
+    private val service: GoogleDriveService,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = currentToken()
+        return chain.proceed(
+            chain.request().newBuilder()
+                .header("Authorization", "Bearer ${token.accessToken}")
+                .build(),
+        )
+    }
+
+    private fun currentToken(): GoogleDriveOAuth = synchronized(this) {
+        val stored = service.loadToken()
+            ?: throw IOException("Google Drive: not signed in")
+        if (!stored.isExpired()) return stored
+
+        val refreshed = service.auth.refresh(stored)
+        service.saveToken(refreshed)
+        return refreshed
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveOAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveOAuth.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * OAuth token set for Google Drive, persisted as JSON in the preference store.
+ *
+ * [obtainedAt] is stamped locally when the token is received, since Google only
+ * reports a relative [expiresIn].
+ */
+@Serializable
+data class GoogleDriveOAuth(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("expires_in") val expiresIn: Long = 3600,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("token_type") val tokenType: String = "Bearer",
+    @SerialName("scope") val scope: String? = null,
+    @SerialName("obtained_at") val obtainedAt: Long = 0,
+) {
+    /** Treats the token as expired a minute early to avoid racing the boundary. */
+    fun isExpired(): Boolean =
+        System.currentTimeMillis() > obtainedAt + (expiresIn - 60).coerceAtLeast(0) * 1000
+
+    fun stamped(refreshTokenFallback: String? = null): GoogleDriveOAuth = copy(
+        refreshToken = refreshToken ?: refreshTokenFallback,
+        obtainedAt = System.currentTimeMillis(),
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDrivePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDrivePreferences.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import tachiyomi.core.common.preference.PreferenceStore
+
+class GoogleDrivePreferences(
+    private val preferenceStore: PreferenceStore,
+) {
+    /** Serialized [GoogleDriveOAuth]; empty when signed out. */
+    val token = preferenceStore.getString(TOKEN_KEY, "")
+
+    /** Shown in settings so the user can tell which account is linked. */
+    val accountEmail = preferenceStore.getString("gdrive_account_email", "")
+
+    /** OAuth credentials from the user's own Google Cloud project. */
+    val clientId = preferenceStore.getString("gdrive_client_id", "")
+    val clientSecret = preferenceStore.getString("gdrive_client_secret", "")
+
+    /** Drive file id of the folder Mihon stores everything under. */
+    val rootFolderId = preferenceStore.getString("gdrive_root_folder_id", "")
+
+    companion object {
+        const val TOKEN_KEY = "gdrive_oauth_token"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/storage/gdrive/GoogleDriveService.kt
@@ -1,0 +1,143 @@
+package eu.kanade.tachiyomi.data.storage.gdrive
+
+import android.app.Application
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import logcat.LogPriority
+import okhttp3.OkHttpClient
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.storage.service.StoragePreferences
+import tachiyomi.i18n.sy.SYMR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Entry point for everything Google Drive: credentials, the authenticated HTTP
+ * client, and the folder the app keeps its library in.
+ */
+class GoogleDriveService(
+    private val context: Application,
+    networkHelper: NetworkHelper,
+    val preferences: GoogleDrivePreferences,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Outlives any screen. The redirect only arrives after the user has left for
+     * the browser, so a composition-scoped job would be cancelled — closing the
+     * loopback socket — before Google ever calls back.
+     */
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Deliberately unauthenticated: token calls must not recurse through the interceptor. */
+    val auth = GoogleDriveAuth(networkHelper.client, preferences)
+
+    private val authedClient: OkHttpClient by lazy {
+        networkHelper.client.newBuilder()
+            .addInterceptor(GoogleDriveInterceptor(this))
+            .build()
+    }
+
+    val api: GoogleDriveApi by lazy { GoogleDriveApi(authedClient) }
+
+    val isConfigured: Boolean
+        get() = auth.getEffectiveClientId().isNotBlank() &&
+            auth.getEffectiveClientSecret().isNotBlank()
+
+    val isSignedIn: Boolean
+        get() = loadToken() != null
+
+    fun loadToken(): GoogleDriveOAuth? = try {
+        preferences.token.get()
+            .takeIf { it.isNotBlank() }
+            ?.let { json.decodeFromString<GoogleDriveOAuth>(it) }
+    } catch (_: Exception) {
+        null
+    }
+
+    fun saveToken(token: GoogleDriveOAuth?) {
+        preferences.token.set(token?.let { json.encodeToString(it) }.orEmpty())
+    }
+
+    fun signOut() {
+        saveToken(null)
+        preferences.accountEmail.set("")
+        preferences.rootFolderId.set("")
+        try {
+            val storagePreferences = Injekt.get<StoragePreferences>()
+            if (storagePreferences.baseStorageDirectory.get().startsWith(URI_SCHEME)) {
+                storagePreferences.baseStorageDirectory.delete()
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to reset storage directory on sign out" }
+        }
+    }
+
+    /**
+     * Waits for Google to hit the loopback socket opened by [session], then stores
+     * the token and automatically configures Google Drive as the storage location.
+     */
+    fun completeSignIn(session: GoogleDriveAuth.Session) {
+        GoogleDriveAuthService.start(context)
+        scope.launch {
+            logcat(LogPriority.INFO) { "gdrive: completeSignIn started" }
+            val message = try {
+                saveToken(auth.awaitToken(session))
+                try {
+                    val about = api.getAbout()
+                    val email = about?.user?.emailAddress ?: about?.user?.displayName
+                    if (!email.isNullOrBlank()) {
+                        preferences.accountEmail.set(email)
+                    }
+                } catch (_: Exception) {
+                }
+                try {
+                    val folderId = ensureRootFolder()
+                    val storagePreferences = Injekt.get<StoragePreferences>()
+                    storagePreferences.baseStorageDirectory.set("${GoogleDriveService.URI_SCHEME}://$folderId")
+                } catch (e: Exception) {
+                    logcat(LogPriority.ERROR, e) { "Failed to auto-configure Google Drive storage directory" }
+                }
+                context.stringResource(SYMR.strings.gdrive_sign_in_success)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Google Drive sign-in failed" }
+                e.message ?: "Google Drive sign-in failed"
+            } finally {
+                GoogleDriveAuthService.stop(context)
+            }
+            withContext(Dispatchers.Main) { context.toast(message) }
+        }
+    }
+
+    /**
+     * Finds — or creates — the app's library folder and caches its id.
+     *
+     * With the `drive.file` scope, listing `root` only ever surfaces entries this
+     * app made, so a name match here cannot collide with the user's own files.
+     */
+    fun ensureRootFolder(): String {
+        preferences.rootFolderId.get()
+            .takeIf { it.isNotBlank() }
+            ?.let { cached -> if (api.getEntry(cached)?.trashed == false) return cached }
+
+        val existing = api.listChildren("root")
+            .firstOrNull { it.isFolder && it.name == LIBRARY_FOLDER_NAME }
+        val folder = existing ?: api.createFolder("root", LIBRARY_FOLDER_NAME)
+        preferences.rootFolderId.set(folder.id)
+        return folder.id
+    }
+
+    companion object {
+        const val LIBRARY_FOLDER_NAME = "TachiyomiSY"
+
+        /** Scheme used by the storage-location preference, e.g. `gdrive://root`. */
+        const val URI_SCHEME = "gdrive"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/SYPreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/SYPreferenceModule.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.di
 
 import android.app.Application
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDrivePreferences
+import eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService
 import exh.pref.DelegateSourcePreferences
 import exh.source.ExhPreferences
 import uy.kohesive.injekt.api.InjektRegistrar
@@ -16,6 +18,24 @@ class SYPreferenceModule(val application: Application) : InjektModule {
 
         addSingletonFactory {
             ExhPreferences(get())
+        }
+
+        addSingletonFactory {
+            GoogleDrivePreferences(get())
+        }
+
+        addSingletonFactory {
+            GoogleDriveService(
+                context = application,
+                networkHelper = get(),
+                preferences = get(),
+            )
+        }
+
+        addSingletonFactory {
+            eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveIndexManager(
+                service = get(),
+            )
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -286,6 +286,7 @@ class LibraryScreenModel(
         ) { prefs, trackFilters ->
             listOf(
                 prefs.filterDownloaded,
+                prefs.filterCloud,
                 prefs.filterUnread,
                 prefs.filterStarted,
                 prefs.filterBookmarked,
@@ -344,9 +345,13 @@ class LibraryScreenModel(
         trackingFilter: Map<Long, TriState>,
         preferences: ItemPreferences,
     ): List<LibraryItem> {
+        val storagePreferences = uy.kohesive.injekt.Injekt.get<tachiyomi.domain.storage.service.StoragePreferences>()
+        val isDrive = storagePreferences.baseStorageDirectory.get().startsWith(eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService.URI_SCHEME)
+
         val downloadedOnly = preferences.globalFilterDownloaded
         val skipOutsideReleasePeriod = preferences.skipOutsideReleasePeriod
         val filterDownloaded = if (downloadedOnly) TriState.ENABLED_IS else preferences.filterDownloaded
+        val filterCloud = preferences.filterCloud
         val filterUnread = preferences.filterUnread
         val filterStarted = preferences.filterStarted
         val filterBookmarked = preferences.filterBookmarked
@@ -364,7 +369,11 @@ class LibraryScreenModel(
         // SY <--
 
         val filterFnDownloaded: (LibraryItem) -> Boolean = {
-            applyFilter(filterDownloaded) { it.isLocal || it.downloadCount > 0 }
+            applyFilter(filterDownloaded) { it.isLocal || (!isDrive && it.downloadCount > 0) }
+        }
+
+        val filterFnCloud: (LibraryItem) -> Boolean = {
+            applyFilter(filterCloud) { isDrive && it.downloadCount > 0 }
         }
 
         val filterFnUnread: (LibraryItem) -> Boolean = {
@@ -410,6 +419,7 @@ class LibraryScreenModel(
 
         return fastFilter {
             filterFnDownloaded(it) &&
+                filterFnCloud(it) &&
                 filterFnUnread(it) &&
                 filterFnStarted(it) &&
                 filterFnBookmarked(it) &&
@@ -602,6 +612,7 @@ class LibraryScreenModel(
 
             preferences.downloadedOnly.changes(),
             libraryPreferences.filterDownloaded.changes(),
+            libraryPreferences.filterCloud.changes(),
             libraryPreferences.filterUnread.changes(),
             libraryPreferences.filterStarted.changes(),
             libraryPreferences.filterBookmarked.changes(),
@@ -619,13 +630,14 @@ class LibraryScreenModel(
                 skipOutsideReleasePeriod = LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in (it[4] as Set<*>),
                 globalFilterDownloaded = it[5] as Boolean,
                 filterDownloaded = it[6] as TriState,
-                filterUnread = it[7] as TriState,
-                filterStarted = it[8] as TriState,
-                filterBookmarked = it[9] as TriState,
-                filterCompleted = it[10] as TriState,
-                filterIntervalCustom = it[11] as TriState,
+                filterCloud = it[7] as TriState,
+                filterUnread = it[8] as TriState,
+                filterStarted = it[9] as TriState,
+                filterBookmarked = it[10] as TriState,
+                filterCompleted = it[11] as TriState,
+                filterIntervalCustom = it[12] as TriState,
                 // SY -->
-                filterLewd = it[12] as TriState,
+                filterLewd = it[13] as TriState,
                 // SY <--
             )
         }
@@ -1462,6 +1474,7 @@ class LibraryScreenModel(
 
         val globalFilterDownloaded: Boolean,
         val filterDownloaded: TriState,
+        val filterCloud: TriState,
         val filterUnread: TriState,
         val filterStarted: TriState,
         val filterBookmarked: TriState,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -61,7 +61,9 @@ internal class DownloadPageLoader(
         val pages = downloadManager.buildPageList(source, manga, chapter.chapter.toDomainChapter()!!)
         return pages.map { page ->
             ReaderPage(page.index, page.url, page.imageUrl) {
-                context.contentResolver.openInputStream(page.uri ?: Uri.EMPTY)!!
+                val uri = page.uri ?: Uri.EMPTY
+                UniFile.fromUri(context, uri)?.openInputStream()
+                    ?: context.contentResolver.openInputStream(uri)!!
             }.apply {
                 status = Page.State.Ready
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -134,6 +134,7 @@ class UpdatesScreenModel(
                 listOf(
                     prefs.filterUnread,
                     prefs.filterDownloaded,
+                    prefs.filterCloud,
                     prefs.filterStarted,
                     prefs.filterBookmarked,
                 )
@@ -151,16 +152,26 @@ class UpdatesScreenModel(
     private fun List<UpdatesItem>.applyFilters(
         preferences: ItemPreferences,
     ): List<UpdatesItem> {
+        val storagePreferences = uy.kohesive.injekt.Injekt.get<tachiyomi.domain.storage.service.StoragePreferences>()
+        val isDrive = storagePreferences.baseStorageDirectory.get().startsWith(eu.kanade.tachiyomi.data.storage.gdrive.GoogleDriveService.URI_SCHEME)
+
         val filterDownloaded = preferences.filterDownloaded
+        val filterCloud = preferences.filterCloud
 
         val filterFnDownloaded: (UpdatesItem) -> Boolean = {
             applyFilter(filterDownloaded) {
-                it.downloadStateProvider() == Download.State.DOWNLOADED
+                !isDrive && it.downloadStateProvider() == Download.State.DOWNLOADED
+            }
+        }
+
+        val filterFnCloud: (UpdatesItem) -> Boolean = {
+            applyFilter(filterCloud) {
+                isDrive && it.downloadStateProvider() == Download.State.DOWNLOADED
             }
         }
 
         return fastFilter {
-            filterFnDownloaded(it)
+            filterFnDownloaded(it) && filterFnCloud(it)
         }
     }
 
@@ -428,17 +439,19 @@ class UpdatesScreenModel(
     private fun getUpdatesItemPreferenceFlow(): Flow<ItemPreferences> {
         return combine(
             updatesPreferences.filterDownloaded.changes(),
+            updatesPreferences.filterCloud.changes(),
             updatesPreferences.filterUnread.changes(),
             updatesPreferences.filterStarted.changes(),
             updatesPreferences.filterBookmarked.changes(),
             updatesPreferences.filterExcludedScanlators.changes(),
-        ) { downloaded, unread, started, bookmarked, excludedScanlators ->
+        ) { it: Array<Any?> ->
             ItemPreferences(
-                filterDownloaded = downloaded,
-                filterUnread = unread,
-                filterStarted = started,
-                filterBookmarked = bookmarked,
-                filterExcludedScanlators = excludedScanlators,
+                filterDownloaded = it[0] as TriState,
+                filterCloud = it[1] as TriState,
+                filterUnread = it[2] as TriState,
+                filterStarted = it[3] as TriState,
+                filterBookmarked = it[4] as TriState,
+                filterExcludedScanlators = it[5] as Boolean,
             )
         }
     }
@@ -450,6 +463,7 @@ class UpdatesScreenModel(
     @Immutable
     private data class ItemPreferences(
         val filterDownloaded: TriState,
+        val filterCloud: TriState,
         val filterUnread: TriState,
         val filterStarted: TriState,
         val filterBookmarked: TriState,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -75,6 +75,11 @@ class LibraryPreferences(
         TriState.DISABLED,
     )
 
+    val filterCloud: Preference<TriState> = preferenceStore.getEnum(
+        "pref_filter_library_cloud_v2",
+        TriState.DISABLED,
+    )
+
     val filterUnread: Preference<TriState> = preferenceStore.getEnum("pref_filter_library_unread_v2", TriState.DISABLED)
 
     val filterStarted: Preference<TriState> = preferenceStore.getEnum(

--- a/domain/src/main/java/tachiyomi/domain/updates/service/UpdatesPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/updates/service/UpdatesPreferences.kt
@@ -14,6 +14,11 @@ class UpdatesPreferences(
         TriState.DISABLED,
     )
 
+    val filterCloud: Preference<TriState> = preferenceStore.getEnum(
+        "pref_filter_updates_cloud",
+        TriState.DISABLED,
+    )
+
     val filterUnread: Preference<TriState> = preferenceStore.getEnum(
         "pref_filter_updates_unread",
         TriState.DISABLED,

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -738,4 +738,36 @@
 
     <!-- Humanize time -->
     <string name="humanize_fallback">moments ago</string>
+
+    <!-- Google Drive storage -->
+    <string name="pref_category_google_drive">Google Drive</string>
+    <string name="pref_gdrive_client_id">OAuth client ID</string>
+    <string name="pref_gdrive_client_secret">OAuth client secret</string>
+    <string name="pref_gdrive_sign_in">Sign in to Google Drive</string>
+    <string name="pref_gdrive_sign_out">Sign out of Google Drive</string>
+    <string name="gdrive_sign_in_started">Finish signing in with the browser that just opened</string>
+    <string name="gdrive_sign_in_success">Google Drive connected</string>
+    <string name="gdrive_filter_downloaded_local">Downloaded locally</string>
+    <string name="gdrive_filter_stored_in_cloud">Stored in the cloud (Google Drive)</string>
+    <string name="gdrive_cbz_unavailable">Not available with Google Drive. Chapters stay as folders so pages can stream instantly.</string>
+    <string name="gdrive_storage_label">Google Drive</string>
+    <string name="gdrive_storage_label_account">Google Drive (%1$s)</string>
+    <string name="gdrive_onboarding_linked">Google Drive linked - tap to switch account</string>
+    <string name="gdrive_onboarding_use">Use Google Drive - no space used on this device</string>
+    <string name="gdrive_signed_in_summary">Linked%1$s - storage location switched to Google Drive</string>
+    <string name="gdrive_sign_in_summary">Sign in to keep chapters in Google Drive and stream them from the cloud</string>
+    <string name="gdrive_signed_out">Signed out of Google Drive; storage is back on this device</string>
+    <string name="gdrive_advanced_hide">Hide API credentials</string>
+    <string name="gdrive_advanced_show">API credentials</string>
+    <string name="gdrive_advanced_summary">Supply an OAuth client from your own Google Cloud project</string>
+    <string name="gdrive_backup_now">Back up to Google Drive now</string>
+    <string name="gdrive_backup_now_summary">Copies your library, settings and progress to TachiyomiSY/autobackup in Drive</string>
+    <string name="gdrive_backup_started">Creating a Google Drive backup in the background</string>
+    <string name="gdrive_restore_from_cloud">Restore from a Google Drive backup</string>
+    <string name="gdrive_restore_from_cloud_summary">Pick a backup stored in your Google Drive</string>
+    <string name="gdrive_restore_dialog_title">Select a Google Drive backup</string>
+    <string name="gdrive_restore_dialog_empty">No backups found in Google Drive yet. Run Back up to Google Drive now to create the first one.</string>
+    <string name="gdrive_backup_file">Backup file</string>
+    <string name="gdrive_storage_used">Used: %1$s</string>
+    <string name="gdrive_credentials_missing">Please enter your Google OAuth Client ID under API credentials first</string>
 </resources>

--- a/i18n-sy/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -678,4 +678,35 @@
     <string name="final_chapter">終章</string>
     <string name="pref_include_chapter_url_hash">包含章節網址雜湊值</string>
     <string name="pref_include_chapter_url_hash_desc">將章節網址的 MD5 雜湊值前六個字元附加至章節檔案或資料夾名。</string>
+    <!-- Google Drive -->
+    <string name="pref_category_google_drive">Google 雲端硬碟</string>
+    <string name="pref_gdrive_client_id">OAuth Client ID</string>
+    <string name="pref_gdrive_client_secret">OAuth Client Secret</string>
+    <string name="pref_gdrive_sign_in">登入 Google 雲端硬碟</string>
+    <string name="pref_gdrive_sign_out">登出 Google 雲端硬碟</string>
+    <string name="gdrive_sign_in_started">請在剛開啟的瀏覽器中完成登入</string>
+    <string name="gdrive_sign_in_success">已成功連線至 Google 雲端硬碟</string>
+    <string name="gdrive_filter_downloaded_local">已下載至本地</string>
+    <string name="gdrive_filter_stored_in_cloud">存放於雲端 (Google Drive)</string>
+    <string name="gdrive_cbz_unavailable">使用 Google 雲端硬碟時不可用（已強制使用資料夾以支援 0 秒即時串流閱讀）</string>
+    <string name="gdrive_storage_label">Google 雲端硬碟</string>
+    <string name="gdrive_storage_label_account">Google 雲端硬碟 (%1$s)</string>
+    <string name="gdrive_onboarding_linked">已連結 Google 雲端硬碟 - 點擊以切換帳號</string>
+    <string name="gdrive_onboarding_use">使用 Google 雲端硬碟 - 不佔用本機儲存空間</string>
+    <string name="gdrive_signed_in_summary">已連結%1$s - 儲存位置已切換至 Google 雲端硬碟</string>
+    <string name="gdrive_sign_in_summary">登入後將漫畫資料夾存放在 Google 雲端硬碟，並隨時即時串流閱讀</string>
+    <string name="gdrive_signed_out">已登出 Google 雲端硬碟；儲存位置已還原至本機</string>
+    <string name="gdrive_advanced_hide">隱藏 API 憑證設定</string>
+    <string name="gdrive_advanced_show">API 憑證設定</string>
+    <string name="gdrive_advanced_summary">自訂您自己的 Google Cloud 專案 OAuth 憑證</string>
+    <string name="gdrive_backup_now">☁️ 立即備份至 Google 雲端</string>
+    <string name="gdrive_backup_now_summary">將書櫃、設定與閱讀進度備份至 Google 雲端硬碟 (TachiyomiSY/autobackup)</string>
+    <string name="gdrive_backup_started">正在背景建立 Google 雲端備份...</string>
+    <string name="gdrive_restore_from_cloud">☁️ 從 Google 雲端備份還原</string>
+    <string name="gdrive_restore_from_cloud_summary">瀏覽並選取 Google 雲端硬碟上的備份檔案進行還原</string>
+    <string name="gdrive_restore_dialog_title">選取 Google 雲端備份</string>
+    <string name="gdrive_restore_dialog_empty">Google 雲端硬碟尚未找到備份檔案。\n你可以先點擊「立即備份至 Google 雲端」建立第一份備份！</string>
+    <string name="gdrive_backup_file">備份檔案</string>
+    <string name="gdrive_storage_used">已使用：%1$s</string>
+    <string name="gdrive_credentials_missing">請先展開「API 憑證設定」填寫您的 Google OAuth Client ID</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR introduces native **Google Drive cloud storage integration** into TachiyomiSY, allowing users to keep their manga library, downloaded chapters, and backups stored directly on Google Drive without taking up local device storage space, while enabling instant (zero-latency) cloud page streaming.

## Key Features & Changes
1. **Google Drive Storage Provider (\gdrive://\)**:
   - Implements a lightweight UniFile virtual filesystem backed by Google Drive REST API v3 and OAuth PKCE authentication.
   - Users can link their Google Drive account under **Settings -> Data and storage -> Storage location**.

2. **0-Latency Cloud Streaming**:
   - Downloads on Google Drive remain uncompressed as folders to support page-by-page streaming directly from the cloud.
   - The 'Save chapters as CBZ' option is disabled with a clear subtitle note when Google Drive storage is selected.

3. **Anti-Redundancy & Index Management**:
   - Implements a \downloads_index.json\ catalog index and pre-checks in \Downloader\ (\cache.isChapterDownloaded\ & filesystem folder checks) to prevent redundant re-downloads.
   - Deleting downloaded chapters inside the app automatically syncs deletion to Google Drive and updates the cloud index.

4. **Independent Local vs. Cloud Filters**:
   - Adds independent \ilterDownloaded\ ('Downloaded locally') and \ilterCloud\ ('Stored in the cloud (Google Drive)') filters to both **Library** and **Updates** screens.

5. **Cloud Backup & Restore**:
   - Automatic backups auto-save to \TachiyomiSY/autobackup/\ on Google Drive when Drive storage is active.
   - Adds **'Back up to Google Drive now'** (1-click manual cloud backup) and **'Restore from a Google Drive backup'** (interactive cloud backup picker dialog) under Data settings.

6. **Security & i18n Readiness**:
   - **Zero Hardcoded Secrets**: Contains zero developer credentials in git. \DEFAULT_CLIENT_ID\ is empty by default, allowing users to enter custom OAuth credentials in the app UI, or maintainers to inject keys via \gdrive_client_id\ in \uild.gradle.kts\.
   - Full \i18n\ localization keys added to \ase\ (English) and \zh-rTW\ (Traditional Chinese).

## Verification
- Verified build and assembly with \./gradlew :app:assembleDebug\.
- Tested OAuth sign-in flow, folder creation, page streaming, backup creation, restore dialog, and library filtering on Android device.