### PR TITLE
fix(db): defer query notifications until RETURNING inserts commit

### DIFF
--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -46,14 +46,16 @@ class CategoryRepositoryImpl(
 
     // SY -->
     override suspend fun insert(category: Category): Long? {
-        return database.categoriesQueries.insert(
-            name = category.name,
-            order = category.order,
-            flags = category.flags,
-            version = category.version,
-            uid = category.uid,
-            last_modified_at = category.lastModifiedAt,
-        ).awaitAsOneOrNull()
+        return database.transactionWithResult {
+            database.categoriesQueries.insert(
+                name = category.name,
+                order = category.order,
+                flags = category.flags,
+                version = category.version,
+                uid = category.uid,
+                last_modified_at = category.lastModifiedAt,
+            ).awaitAsOneOrNull()
+        }
     }
     // SY <--
 

--- a/data/src/main/java/tachiyomi/data/manga/MangaMergeRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMergeRepositoryImpl.kt
@@ -88,20 +88,22 @@ class MangaMergeRepositoryImpl(
     }
 
     override suspend fun insert(reference: MergedMangaReference): Long? {
-        return database.mergedQueries
-            .insertReturningId(
-                infoManga = reference.isInfoManga,
-                getChapterUpdates = reference.getChapterUpdates,
-                chapterSortMode = reference.chapterSortMode.toLong(),
-                chapterPriority = reference.chapterPriority.toLong(),
-                downloadChapters = reference.downloadChapters,
-                mergeId = reference.mergeId!!,
-                mergeUrl = reference.mergeUrl,
-                mangaId = reference.mangaId,
-                mangaUrl = reference.mangaUrl,
-                mangaSource = reference.mangaSourceId,
-            )
-            .awaitAsOneOrNull()
+        return database.transactionWithResult {
+            database.mergedQueries
+                .insertReturningId(
+                    infoManga = reference.isInfoManga,
+                    getChapterUpdates = reference.getChapterUpdates,
+                    chapterSortMode = reference.chapterSortMode.toLong(),
+                    chapterPriority = reference.chapterPriority.toLong(),
+                    downloadChapters = reference.downloadChapters,
+                    mergeId = reference.mergeId!!,
+                    mergeUrl = reference.mergeUrl,
+                    mangaId = reference.mangaId,
+                    mangaUrl = reference.mangaUrl,
+                    mangaSource = reference.mangaSourceId,
+                )
+                .awaitAsOneOrNull()
+        }
     }
 
     override suspend fun insertAll(references: List<MergedMangaReference>) {

--- a/data/src/main/java/tachiyomi/data/source/FeedSavedSearchRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/FeedSavedSearchRepositoryImpl.kt
@@ -67,11 +67,13 @@ class FeedSavedSearchRepositoryImpl(
     }
 
     override suspend fun insert(feedSavedSearch: FeedSavedSearch): Long {
-        return database.feed_saved_searchQueries.insertReturningId(
-            feedSavedSearch.source,
-            feedSavedSearch.savedSearch,
-            feedSavedSearch.global,
-        ).awaitAsOne()
+        return database.transactionWithResult {
+            database.feed_saved_searchQueries.insertReturningId(
+                feedSavedSearch.source,
+                feedSavedSearch.savedSearch,
+                feedSavedSearch.global,
+            ).awaitAsOne()
+        }
     }
 
     override suspend fun insertAll(feedSavedSearch: List<FeedSavedSearch>) {

--- a/data/src/main/java/tachiyomi/data/source/SavedSearchRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/SavedSearchRepositoryImpl.kt
@@ -37,12 +37,14 @@ class SavedSearchRepositoryImpl(
     }
 
     override suspend fun insert(savedSearch: SavedSearch): Long {
-        return database.saved_searchQueries.insertReturningId(
-            savedSearch.source,
-            savedSearch.name,
-            savedSearch.query,
-            savedSearch.filtersJson,
-        ).awaitAsOne()
+        return database.transactionWithResult {
+            database.saved_searchQueries.insertReturningId(
+                savedSearch.source,
+                savedSearch.name,
+                savedSearch.query,
+                savedSearch.filtersJson,
+            ).awaitAsOne()
+        }
     }
 
     override suspend fun insertAll(savedSearch: List<SavedSearch>) {


### PR DESCRIPTION
While testing E2E for SyncYomi I found a bug: the category list is not updating when creating one, and we have to get out of the screen and go back in to see it, even though the db row was already written. This should fix it. 

The cause: with `generateAsync`, sqldelight fires the change notification for `INSERT ... RETURNING` before the insert actually runs, so the screen re-queries too early and shows the old list. Running the insert inside a transaction delays the notification until commit. Saved searches, feed and merged manga inserts had the same problem so I changed those too.

## Before

[Screen_recording_20260901_190358.webm](https://github.com/user-attachments/assets/78352354-5f2c-4e2d-a256-ad2095a34641)

## After

[Works.webm](https://github.com/user-attachments/assets/13e2fd6d-1bfc-4ca0-bdd9-a13e762e14e9)
